### PR TITLE
fix(openapi-codegen): fix property "main" in package json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "openapi-codegen-typescript",
     "version": "0.1.2",
     "description": "OpenApi codegen for generating types an mocks from swagger json file",
-    "main": "dist/index.ts",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "repository": "LandrAudio/openapi-codegen-typescript",
     "author": {

--- a/tests/mockConverter.test.ts
+++ b/tests/mockConverter.test.ts
@@ -220,7 +220,7 @@ export const aBooleanAPI = (overrides?: Partial<Boolean>): Boolean => {
         const expectedString = `
 export const aDatesAPI = (overrides?: Partial<Dates>): Dates => {
   return {
-    refType: [anAssetDtoAPI()],
+    refType: overrides?.hasOwnProperty('refType') ? overrides?.refType : [anAssetDtoAPI()],
   oneOf: ['Community'],
   simpleType: ['pariatur'],
   maxItems: ['autem'],
@@ -283,7 +283,7 @@ export const anAssetDtoAPI = (overrides?: Partial<AssetDto>): AssetDto => {
   name: 'name-assetdto',
   isConfigured: true,
   type: 'Audio',
-  files: [anAssetFileDtoAPI()],
+  files: overrides?.hasOwnProperty('files') ? overrides?.files : [anAssetFileDtoAPI()],
   ...overrides,
   };
 };
@@ -343,8 +343,8 @@ export const anAssetDtoAPI = (overrides?: Partial<AssetDto>): AssetDto => {
         const expectedString = `
 export const aServiceTypeDtoAPI = (overrides?: Partial<ServiceTypeDto>): ServiceTypeDto => {
   return {
-    serviceCategory: aServiceCategoryDtoAPI(),
-  priceRanges: [aServiceTypePriceRangeDtoAPI()],
+    serviceCategory: overrides?.hasOwnProperty('serviceCategory') ? overrides?.serviceCategory : aServiceCategoryDtoAPI(),
+  priceRanges: overrides?.hasOwnProperty('priceRanges') ? overrides?.priceRanges : [aServiceTypePriceRangeDtoAPI()],
   code: 'code-servicetypedto',
   ...overrides,
   };
@@ -416,7 +416,7 @@ export const aCreateBriefDtoAPI = (overrides?: Partial<CreateBriefDto>): CreateB
   description: 'description-createbriefdto',
   briefType: 'Contest',
   inspirationalLinks: ['ipsa'],
-  serviceType: aServiceTypeBasicDtoAPI(),
+  serviceType: overrides?.hasOwnProperty('serviceType') ? overrides?.serviceType : aServiceTypeBasicDtoAPI(),
   providerServiceId: '674371a6-fd8b-41b2-94f0-321c64b7e346',
   ...overrides,
   };
@@ -546,7 +546,7 @@ export const aPatchBriefDtoAPI = (overrides?: Partial<PatchBriefDto>): PatchBrie
         const expectedString = `
 export const aCreateServiceDtoAPI = (overrides?: Partial<CreateServiceDto>): CreateServiceDto => {
   return {
-    serviceType: aServiceTypeBasicDtoAPI(),
+    serviceType: overrides?.hasOwnProperty('serviceType') ? overrides?.serviceType : aServiceTypeBasicDtoAPI(),
   ...overrides,
   };
 };


### PR DESCRIPTION
1. Fixed "main" field in package.json file from 'index.ts' - to 'index.js' value.
2. Added "hasOwnProperty" to mock result. Reason is that we cannot override mock props that has recursion. **Example**:
``` javascript
export const anAssignmentDtoAPI = (overrides?: Partial<AssignmentDto>): AssignmentDto => {
    return {
        ...
        pitch: aPitchDtoAPI(),
        brief: aBriefDtoAPI(),
        ...overrides,
    };
};

export const aBriefDtoAPI = (overrides?: Partial<BriefDto>): BriefDto => {
    return {
       ...
        assignment: anAssignmentDtoAPI(),
        ...overrides,
    };
};

export const aPitchDtoAPI = (overrides?: Partial<PitchDto>): PitchDto => {
    return {
        brief: aBriefDtoAPI(),
        ...overrides,
    };
};
```
Simple spread operator will not work in this case, because JS will evaluate "return" object first and only then will "override" properties which will lead to error : `RangeError: Maximum call stack size exceeded`