### PR TITLE
fix(mocks-codegen): fix email and duration mocks, fix multiple extend DTOs mocks, add and use 'indefinite' npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
         "typescript": "3.8.2"
     },
     "dependencies": {
+        "@types/indefinite": "^2.3.0",
         "casual": "1.6.2",
+        "indefinite": "^2.3.2",
         "node-fetch": "2.6.0"
     },
     "files": [

--- a/src/MockGenerateHelper.ts
+++ b/src/MockGenerateHelper.ts
@@ -1,0 +1,205 @@
+import casual from 'casual';
+import indefinite from 'indefinite';
+import { hashedString } from './shared';
+import {
+    ConvertRefType,
+    DataTypes,
+    GetArrayOfItemsMockProps,
+    GetArrayOfOneOfMockProps,
+    GetNumberMockProps,
+    GetRefTypeMockProps,
+    GetStringMockProps,
+    MockArrayProps,
+    PropertyNames,
+    StringFormats,
+    SwaggerProps,
+} from './types';
+
+export class MockGenerateHelper {
+    private casual: any;
+
+    constructor(casual: any) {
+        this.casual = casual;
+    }
+
+    getStringMock({ name, propertyName, format }: GetStringMockProps): MockArrayProps {
+        this.casual.seed(hashedString(name + propertyName));
+        let value;
+
+        if (!format) {
+            // simple string
+            value = `'${propertyName}-${name.toLowerCase()}'`;
+        } else if (format === StringFormats.Guid || propertyName === PropertyNames.Id) {
+            value = `'${this.casual.uuid}'`;
+        } else if (format === StringFormats.DateTime || format === StringFormats.TimeSpan) {
+            value = `'2019-06-10T06:20:01.389Z'`;
+        } else if (format === StringFormats.Date) {
+            value = `'2019-06-10'`;
+        } else if (format === StringFormats.Email) {
+            value = `'${this.casual.email}'`;
+        }
+
+        if (!value) {
+            value = 'TODO: FIX';
+        }
+
+        return {
+            propertyName,
+            value,
+        };
+    }
+
+    /**
+     * Returns mock data for types 'integer' and 'double'
+     * @param propertyName
+     * @param type
+     * @param minimum
+     * @param maximum
+     */
+    getNumberMock({ propertyName, type, minimum, maximum }: GetNumberMockProps): MockArrayProps {
+        return {
+            propertyName,
+            value:
+                type === DataTypes.Integer
+                    ? casual.integer(minimum || 0, maximum || 30)
+                    : casual.double(minimum || 0, maximum || 30),
+        };
+    }
+
+    /**
+     * Returns mock data for type 'boolean'
+     * @param propertyName
+     */
+    getBooleanMock(propertyName: string): MockArrayProps {
+        return {
+            propertyName,
+            value: true,
+        };
+    }
+
+    /**
+     * Returns mock data for array of values.
+     * Could return array of DTOs, Enums, Strings, Doubles...
+     * @param propertyName
+     * @param items
+     * @param DTOs
+     */
+    getArrayOfItemsMock({ propertyName, items, DTOs }: GetArrayOfItemsMockProps): MockArrayProps {
+        let result = {
+            propertyName: `TODO: FIX ERROR in ${propertyName}`,
+            value: 'NULL',
+        } as MockArrayProps;
+
+        if (items[SwaggerProps.$ref]) {
+            const refType = items[SwaggerProps.$ref].split('/');
+
+            const ref = MockGenerateHelper.parseRefType(refType);
+
+            const schema = DTOs[ref];
+            if (schema && schema.enum) {
+                result = { propertyName, value: `['${schema.enum[0]}']` };
+            } else {
+                result = MockGenerateHelper.convertRefType({ propertyName, ref, isArray: true });
+            }
+        } else {
+            const type = items.oneOf
+                ? MockGenerateHelper.parseRefType(items.oneOf[0][SwaggerProps.$ref].split('/'))
+                : items.type;
+
+            if (items.oneOf) {
+                const schema = DTOs[type];
+                if (schema && schema.enum) {
+                    result = { propertyName, value: `['${schema.enum[0]}']` };
+                }
+            } else {
+                if (items.type === DataTypes.Number) {
+                    result = { propertyName, value: `[${casual.double()},${casual.double()}]` };
+                } else {
+                    result = { propertyName, value: `['${casual.word}']` };
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Return one element of Enum or DTO
+     * @param propertyName
+     * @param oneOf
+     * @param DTOs
+     */
+    getDtoMock({ propertyName, oneOf, DTOs }: GetArrayOfOneOfMockProps): MockArrayProps {
+        const refType = oneOf[0][SwaggerProps.$ref].split('/');
+
+        const ref = MockGenerateHelper.parseRefType(refType);
+
+        const schema = DTOs[ref];
+        if (schema && schema.enum) {
+            return { propertyName, value: `'${schema.enum[0]}'` };
+        } else {
+            return MockGenerateHelper.convertRefType({ propertyName, ref });
+        }
+    }
+
+    getRefTypeMock = ({ $ref, propertyName, DTOs }: GetRefTypeMockProps): MockArrayProps => {
+        let result = {
+            propertyName: `TODO: FIX ERROR in ${propertyName} ref:${$ref}`,
+            value: 'NULL',
+        } as MockArrayProps;
+
+        const refType = $ref.split('/');
+
+        const ref = MockGenerateHelper.parseRefType(refType);
+
+        const schema = DTOs[ref];
+        if (schema && schema.enum) {
+            result = { propertyName, value: `'${schema.enum[0]}'` };
+        } else if (schema) {
+            result = MockGenerateHelper.convertRefType({ propertyName, ref });
+        }
+
+        return result;
+    };
+
+    static parseRefType = (refType: string[]): string => refType[refType.length - 1];
+
+    static joinVariableNamesAndValues = (varNamesAndValues: Array<MockArrayProps>): string =>
+        varNamesAndValues.map((mock: MockArrayProps) => `  ${mock.propertyName}: ${mock.value},`).join('\n');
+
+    static getMockTemplateString = ({ typeName, varNamesAndValues }: any) => {
+        const prefix = indefinite(typeName, {articleOnly:true});
+        const joinedVarsAndNames = MockGenerateHelper.joinVariableNamesAndValues(varNamesAndValues);
+        return `
+export const ${prefix}${typeName}API = (overrides?: Partial<${typeName}>): ${typeName} => {
+  return {
+  ${joinedVarsAndNames}
+  ...overrides,
+  };
+};
+`;
+    };
+
+    static convertRefType = ({
+        propertyName,
+        ref,
+        isArray = false,
+    }: ConvertRefType): {
+        propertyName: string;
+        value: any;
+    } => {
+        const aOrAn = indefinite(ref, { articleOnly: true });
+
+        let value;
+        if (isArray) {
+            value = `overrides?.${propertyName} || [${aOrAn}${ref}API()]`;
+        } else {
+            value = `overrides?.${propertyName} || ${aOrAn}${ref}API()`;
+        }
+
+        return {
+            propertyName,
+            value,
+        };
+    };
+}

--- a/src/mockConverter.ts
+++ b/src/mockConverter.ts
@@ -47,20 +47,26 @@ function getStringFakeValue({
 }) {
     casual.seed(hashedString(name + propertyName));
 
+    let value;
+
     if (!format) {
-        return `'${propertyName}-${name.toLowerCase()}'`;
+        // simple string
+        value = `'${propertyName}-${name.toLowerCase()}'`;
     } else if (format === StringFormats.Guid || propertyName === PropertyNames.Id) {
-        return `'${casual.uuid}'`;
-    } else {
-        switch (format) {
-            case StringFormats.DateTime: {
-                return `'2019-06-10T06:20:01.389Z'`;
-            }
-            case StringFormats.Date: {
-                return `'2019-06-10'`;
-            }
-        }
+        value = `'${casual.uuid}'`;
+    } else if (format === StringFormats.DateTime || format === StringFormats.TimeSpan) {
+        value = `'2019-06-10T06:20:01.389Z'`;
+    } else if (format === StringFormats.Date) {
+        value = `'2019-06-10'`;
+    } else if (format === StringFormats.Email) {
+        value = `'${casual.email}'`;
     }
+
+    if (!value) {
+        value = 'TODO: FIX';
+    }
+
+    return value;
 }
 
 export const getSchemaInterfaces = (schema: any): Array<string> | undefined => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export enum StringFormats {
     Hostname = 'hostname',
     Ipv4 = 'ipv4',
     Ipv6 = 'ipv6',
+    TimeSpan = 'time-span'
 }
 
 export enum StringAdditionalProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,8 +52,14 @@ export enum ArrayAdditionalProps {
     UniqueItems = 'uniqueItems',
 }
 
-export interface ResultStringProps {
+export interface PropertyNameProp {
+    /**
+     * DTO\'s property name
+     */
     propertyName: string;
+}
+
+export interface ResultStringProps extends PropertyNameProp{
     nullable?: boolean;
 }
 
@@ -99,9 +105,36 @@ export interface ResultStringPropsForStringType extends ResultStringProps {
     maxLength?: number;
 }
 
-export interface MockArrayProps {
-    propertyName: string;
+export interface MockArrayProps extends PropertyNameProp{
     value: any;
+}
+
+export interface GetStringMockProps extends PropertyNameProp{
+    name: string;
+    format: string;
+    minLength: number;
+    maxLength: number;
+}
+
+export interface GetNumberMockProps extends PropertyNameProp {
+    type: DataTypes.Integer | DataTypes.Number;
+    minimum: number;
+    maximum: number;
+}
+
+export interface GetArrayOfItemsMockProps extends PropertyNameProp {
+    items: any;
+    DTOs: any;
+}
+
+export interface GetArrayOfOneOfMockProps extends PropertyNameProp {
+    oneOf: any;
+    DTOs: any;
+}
+
+export interface GetRefTypeMockProps extends PropertyNameProp {
+    $ref: string;
+    DTOs: any;
 }
 
 export interface ParseProps {
@@ -116,15 +149,10 @@ export interface SwaggerSchema {
     };
 }
 
-export interface Props {
-    swaggerJsonUrl: string;
+export interface ConvertRefType extends PropertyNameProp {
     /**
-     * Example: './src/types'
+     * Reference to another object DTO
      */
-    folderPath: string;
-    /**
-     * Example: swagger-profiles
-     */
-    fileName: string;
-    shouldGenerateMocks?: boolean;
+    ref: string;
+    isArray?: boolean;
 }

--- a/tests/mockConverter.test.ts
+++ b/tests/mockConverter.test.ts
@@ -5,29 +5,29 @@ import {
     parseSchema,
     parseSchemas,
 } from '../src/mockConverter';
+
 jest.mock('fs');
 
 const fs = require('fs');
 
-describe('Mock generation', () => {
-    it('should generate number type', async () => {
-        const schema = {
-            type: 'object',
-            additionalProperties: false,
-            required: ['serviceType', 'price'],
-            properties: {
-                price: {
-                    type: 'number',
-                    format: 'decimal',
-                    minimum: 0,
-                    maximum: 100,
-                },
+it('should generate number type', async () => {
+    const schema = {
+        type: 'object',
+        additionalProperties: false,
+        required: ['serviceType', 'price'],
+        properties: {
+            price: {
+                type: 'number',
+                format: 'decimal',
+                minimum: 0,
+                maximum: 100,
             },
-        };
+        },
+    };
 
-        const result = parseSchema({ schema, name: 'ServiceTypeDto' });
+    const result = parseSchema({ schema, name: 'ServiceTypeDto' });
 
-        const expectedString = `
+    const expectedString = `
 export const aServiceTypeDtoAPI = (overrides?: Partial<ServiceTypeDto>): ServiceTypeDto => {
   return {
     price: 11.842845170758665,
@@ -35,28 +35,28 @@ export const aServiceTypeDtoAPI = (overrides?: Partial<ServiceTypeDto>): Service
   };
 };
 `;
-        expect(result).toEqual(expectedString);
-    });
+    expect(result).toEqual(expectedString);
+});
 
-    it('should generate array of numbers type', async () => {
-        const schema = {
-            type: "object",
-            additionalProperties: false,
-            properties: {
-                data: {
-                    type: "array",
-                    nullable: true,
-                    items: {
-                        type: "number",
-                        format: "double"
-                    }
+it('should generate array of numbers type', async () => {
+    const schema = {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+            data: {
+                type: 'array',
+                nullable: true,
+                items: {
+                    type: 'number',
+                    format: 'double',
                 },
-            }
-        };
+            },
+        },
+    };
 
-        const result = parseSchema({ schema, name: 'VisualizationDto' });
+    const result = parseSchema({ schema, name: 'VisualizationDto' });
 
-        const expectedString = `
+    const expectedString = `
 export const aVisualizationDtoAPI = (overrides?: Partial<VisualizationDto>): VisualizationDto => {
   return {
     data: [88.24278227984905,107.01676551252604],
@@ -64,101 +64,101 @@ export const aVisualizationDtoAPI = (overrides?: Partial<VisualizationDto>): Vis
   };
 };
 `;
-        expect(result).toEqual(expectedString);
-    });
+    expect(result).toEqual(expectedString);
+});
 
-    it('should get interfaces', async () => {
-        const schema = {
-            allOf: [
-                {
-                    $ref: '#/components/schemas/One',
-                },
-                {
-                    $ref: '#/components/schemas/Two',
-                },
-                {
-                    type: 'object',
-                    properties: {},
-                },
-            ],
-        };
-
-        const result = getSchemaInterfaces(schema);
-        expect(result).toEqual(['One', 'Two']);
-    });
-
-    it('should combine props from interfaces', async () => {
-        const DTOs = {
-            One: {
-                properties: {
-                    name: {
-                        type: 'string',
-                        nullable: 'true',
-                    },
-                },
+it('should get interfaces', async () => {
+    const schema = {
+        allOf: [
+            {
+                $ref: '#/components/schemas/One',
             },
-            Two: {
-                properties: {
-                    price: {
-                        type: 'number',
-                        format: 'decimal',
-                    },
-                },
+            {
+                $ref: '#/components/schemas/Two',
             },
-        };
+            {
+                type: 'object',
+                properties: {},
+            },
+        ],
+    };
 
-        const schema = {
-            type: 'object',
-            additionalProperties: false,
+    const result = getSchemaInterfaces(schema);
+    expect(result).toEqual(['One', 'Two']);
+});
+
+it('should combine props from interfaces', async () => {
+    const DTOs = {
+        One: {
             properties: {
-                dateTime: {
-                    type: 'string',
-                    format: 'date-time',
-                },
-            },
-        };
-
-        const result = combineProperties({ schema, schemas: DTOs, interfaces: ['One', 'Two'] });
-
-        expect(result).toEqual({
-            type: 'object',
-            additionalProperties: false,
-            properties: {
-                dateTime: {
-                    type: 'string',
-                    format: 'date-time',
-                },
                 name: {
                     type: 'string',
                     nullable: 'true',
                 },
+            },
+        },
+        Two: {
+            properties: {
                 price: {
                     type: 'number',
                     format: 'decimal',
                 },
             },
-        });
-    });
+        },
+    };
 
-    it('should generate date-time format', async () => {
-        const schema = {
-            type: 'object',
-            additionalProperties: false,
-            properties: {
-                dateTime: {
-                    type: 'string',
-                    format: 'date-time',
-                },
-                date: {
-                    type: 'string',
-                    format: 'date',
-                },
+    const schema = {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+            dateTime: {
+                type: 'string',
+                format: 'date-time',
             },
-        };
+        },
+    };
 
-        const result = parseSchema({ schema, name: 'Dates' });
+    const result = combineProperties({ schema, schemas: DTOs, interfaces: ['One', 'Two'] });
 
-        const expectedString = `
+    expect(result).toEqual({
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+            dateTime: {
+                type: 'string',
+                format: 'date-time',
+            },
+            name: {
+                type: 'string',
+                nullable: 'true',
+            },
+            price: {
+                type: 'number',
+                format: 'decimal',
+            },
+        },
+    });
+});
+
+it('should generate date-time format', async () => {
+    const schema = {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+            dateTime: {
+                type: 'string',
+                format: 'date-time',
+            },
+            date: {
+                type: 'string',
+                format: 'date',
+            },
+        },
+    };
+
+    const result = parseSchema({ schema, name: 'Dates' });
+
+    const expectedString = `
 export const aDatesAPI = (overrides?: Partial<Dates>): Dates => {
   return {
     dateTime: '2019-06-10T06:20:01.389Z',
@@ -167,23 +167,23 @@ export const aDatesAPI = (overrides?: Partial<Dates>): Dates => {
   };
 };
 `;
-        expect(result).toEqual(expectedString);
-    });
+    expect(result).toEqual(expectedString);
+});
 
-    it('should generate boolean type', async () => {
-        const schema = {
-            type: 'object',
-            additionalProperties: false,
-            properties: {
-                canAccept: {
-                    type: 'boolean',
-                },
+it('should generate boolean type', async () => {
+    const schema = {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+            canAccept: {
+                type: 'boolean',
             },
-        };
+        },
+    };
 
-        const result = parseSchema({ schema, name: 'Boolean' });
+    const result = parseSchema({ schema, name: 'Boolean' });
 
-        const expectedString = `
+    const expectedString = `
 export const aBooleanAPI = (overrides?: Partial<Boolean>): Boolean => {
   return {
     canAccept: true,
@@ -191,62 +191,62 @@ export const aBooleanAPI = (overrides?: Partial<Boolean>): Boolean => {
   };
 };
 `;
-        expect(result).toEqual(expectedString);
-    });
+    expect(result).toEqual(expectedString);
+});
 
-    it('should generate array types', async () => {
-        const DTOs = {
-            PriceTier: {
-                type: 'string',
-                description: '',
-                'x-enumNames': ['Community', 'Bronze', 'Silver', 'Gold', 'Platinum'],
-                enum: ['Community', 'Bronze', 'Silver', 'Gold', 'Platinum'],
-            },
-        };
-        const schema = {
-            type: 'object',
-            additionalProperties: false,
-            properties: {
-                refType: {
-                    type: 'array',
-                    nullable: true,
-                    items: {
-                        $ref: '#/components/schemas/AssetDto',
-                    },
-                },
-                oneOf: {
-                    type: 'array',
-                    nullable: true,
-                    items: {
-                        nullable: true,
-                        oneOf: [
-                            {
-                                $ref: '#/components/schemas/PriceTier',
-                            },
-                        ],
-                    },
-                },
-                simpleType: {
-                    type: 'array',
-                    nullable: true,
-                    items: {
-                        type: 'string',
-                    },
-                },
-                maxItems: {
-                    type: 'array',
-                    maxItems: 5,
-                    nullable: true,
-                    items: {
-                        type: 'string',
-                    },
+it('should generate array types', async () => {
+    const DTOs = {
+        PriceTier: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Community', 'Bronze', 'Silver', 'Gold', 'Platinum'],
+            enum: ['Community', 'Bronze', 'Silver', 'Gold', 'Platinum'],
+        },
+    };
+    const schema = {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+            refType: {
+                type: 'array',
+                nullable: true,
+                items: {
+                    $ref: '#/components/schemas/AssetDto',
                 },
             },
-        };
+            oneOf: {
+                type: 'array',
+                nullable: true,
+                items: {
+                    nullable: true,
+                    oneOf: [
+                        {
+                            $ref: '#/components/schemas/PriceTier',
+                        },
+                    ],
+                },
+            },
+            simpleType: {
+                type: 'array',
+                nullable: true,
+                items: {
+                    type: 'string',
+                },
+            },
+            maxItems: {
+                type: 'array',
+                maxItems: 5,
+                nullable: true,
+                items: {
+                    type: 'string',
+                },
+            },
+        },
+    };
 
-        const result = parseSchema({ schema, name: 'Dates', DTOs });
+    const result = parseSchema({ schema, name: 'Dates', DTOs });
 
-        const expectedString = `
+    const expectedString = `
 export const aDatesAPI = (overrides?: Partial<Dates>): Dates => {
   return {
     refType: overrides?.refType || [anAssetDtoAPI()],
@@ -257,55 +257,55 @@ export const aDatesAPI = (overrides?: Partial<Dates>): Dates => {
   };
 };
 `;
-        expect(result).toEqual(expectedString);
+    expect(result).toEqual(expectedString);
+});
+
+it('should generate AssetDto mocks', async () => {
+    const DTO = {
+        AssetType: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Audio', 'Video', 'Image', 'Youtube'],
+            enum: ['Audio', 'Video', 'Image', 'Youtube'],
+        },
+    };
+
+    const schema = {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+            id: {
+                type: 'string',
+                format: 'guid',
+            },
+            name: {
+                type: 'string',
+                nullable: true,
+            },
+            isConfigured: {
+                type: 'boolean',
+                nullable: true,
+            },
+            type: {
+                $ref: '#/components/schemas/AssetType',
+            },
+            files: {
+                type: 'array',
+                nullable: true,
+                items: {
+                    $ref: '#/components/schemas/AssetFileDto',
+                },
+            },
+        },
+    };
+
+    const result = parseSchema({
+        schema,
+        name: 'AssetDto',
+        DTOs: DTO,
     });
 
-    it('should generate AssetDto mocks', async () => {
-        const DTO = {
-            AssetType: {
-                type: 'string',
-                description: '',
-                'x-enumNames': ['Audio', 'Video', 'Image', 'Youtube'],
-                enum: ['Audio', 'Video', 'Image', 'Youtube'],
-            },
-        };
-
-        const schema = {
-            type: 'object',
-            additionalProperties: false,
-            properties: {
-                id: {
-                    type: 'string',
-                    format: 'guid',
-                },
-                name: {
-                    type: 'string',
-                    nullable: true,
-                },
-                isConfigured: {
-                    type: 'boolean',
-                    nullable: true,
-                },
-                type: {
-                    $ref: '#/components/schemas/AssetType',
-                },
-                files: {
-                    type: 'array',
-                    nullable: true,
-                    items: {
-                        $ref: '#/components/schemas/AssetFileDto',
-                    },
-                },
-            },
-        };
-
-        const result = parseSchema({
-            schema,
-            name: 'AssetDto',
-            DTOs: DTO,
-        });
-
-        const expectedString = `
+    const expectedString = `
 export const anAssetDtoAPI = (overrides?: Partial<AssetDto>): AssetDto => {
   return {
     id: 'b0803452-5ceb-4ba3-ba9f-0c84b4b5262f',
@@ -317,59 +317,59 @@ export const anAssetDtoAPI = (overrides?: Partial<AssetDto>): AssetDto => {
   };
 };
 `;
-        expect(result).toEqual(expectedString);
-    });
+    expect(result).toEqual(expectedString);
+});
 
-    it('should generate mocks for extend interfaces', async () => {
-        const DTOs = {
-            ServiceTypeBasicDto: {
+it('should generate mocks for extend interfaces', async () => {
+    const DTOs = {
+        ServiceTypeBasicDto: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['code'],
+            properties: {
+                code: {
+                    type: 'string',
+                    minLength: 1,
+                },
+            },
+        },
+    };
+    const schema = {
+        allOf: [
+            {
+                $ref: '#/components/schemas/ServiceTypeBasicDto',
+            },
+            {
                 type: 'object',
                 additionalProperties: false,
-                required: ['code'],
                 properties: {
-                    code: {
-                        type: 'string',
-                        minLength: 1,
+                    serviceCategory: {
+                        nullable: true,
+                        oneOf: [
+                            {
+                                $ref: '#/components/schemas/ServiceCategoryDto',
+                            },
+                        ],
+                    },
+                    priceRanges: {
+                        type: 'array',
+                        nullable: true,
+                        items: {
+                            $ref: '#/components/schemas/ServiceTypePriceRangeDto',
+                        },
                     },
                 },
             },
-        };
-        const schema = {
-            allOf: [
-                {
-                    $ref: '#/components/schemas/ServiceTypeBasicDto',
-                },
-                {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        serviceCategory: {
-                            nullable: true,
-                            oneOf: [
-                                {
-                                    $ref: '#/components/schemas/ServiceCategoryDto',
-                                },
-                            ],
-                        },
-                        priceRanges: {
-                            type: 'array',
-                            nullable: true,
-                            items: {
-                                $ref: '#/components/schemas/ServiceTypePriceRangeDto',
-                            },
-                        },
-                    },
-                },
-            ],
-        };
+        ],
+    };
 
-        const result = parseSchema({
-            schema,
-            name: 'ServiceTypeDto',
-            DTOs,
-        });
+    const result = parseSchema({
+        schema,
+        name: 'ServiceTypeDto',
+        DTOs,
+    });
 
-        const expectedString = `
+    const expectedString = `
 export const aServiceTypeDtoAPI = (overrides?: Partial<ServiceTypeDto>): ServiceTypeDto => {
   return {
     serviceCategory: overrides?.serviceCategory || aServiceCategoryDtoAPI(),
@@ -379,66 +379,66 @@ export const aServiceTypeDtoAPI = (overrides?: Partial<ServiceTypeDto>): Service
   };
 };
 `;
-        expect(result).toEqual(expectedString);
+    expect(result).toEqual(expectedString);
+});
+
+it('should generate CreateBriefDto mocks', async () => {
+    const DTOs = {
+        BriefType: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Contest', 'Landr', 'Direct'],
+            enum: ['Contest', 'Landr', 'Direct'],
+        },
+    };
+    const schema = {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+            title: {
+                type: 'string',
+                maxLength: 255,
+                minLength: 1,
+            },
+            description: {
+                type: 'string',
+                maxLength: 4000,
+                minLength: 1,
+            },
+            briefType: {
+                $ref: '#/components/schemas/BriefType',
+            },
+            inspirationalLinks: {
+                type: 'array',
+                maxItems: 5,
+                nullable: true,
+                items: {
+                    type: 'string',
+                },
+            },
+            serviceType: {
+                nullable: true,
+                oneOf: [
+                    {
+                        $ref: '#/components/schemas/ServiceTypeBasicDto',
+                    },
+                ],
+            },
+            providerServiceId: {
+                type: 'string',
+                format: 'guid',
+                nullable: true,
+            },
+        },
+    };
+
+    const result = parseSchema({
+        schema,
+        name: 'CreateBriefDto',
+        DTOs,
     });
 
-    it('should generate CreateBriefDto mocks', async () => {
-        const DTOs = {
-            BriefType: {
-                type: 'string',
-                description: '',
-                'x-enumNames': ['Contest', 'Landr', 'Direct'],
-                enum: ['Contest', 'Landr', 'Direct'],
-            },
-        };
-        const schema = {
-            type: 'object',
-            additionalProperties: false,
-            properties: {
-                title: {
-                    type: 'string',
-                    maxLength: 255,
-                    minLength: 1,
-                },
-                description: {
-                    type: 'string',
-                    maxLength: 4000,
-                    minLength: 1,
-                },
-                briefType: {
-                    $ref: '#/components/schemas/BriefType',
-                },
-                inspirationalLinks: {
-                    type: 'array',
-                    maxItems: 5,
-                    nullable: true,
-                    items: {
-                        type: 'string',
-                    },
-                },
-                serviceType: {
-                    nullable: true,
-                    oneOf: [
-                        {
-                            $ref: '#/components/schemas/ServiceTypeBasicDto',
-                        },
-                    ],
-                },
-                providerServiceId: {
-                    type: 'string',
-                    format: 'guid',
-                    nullable: true,
-                },
-            },
-        };
-
-        const result = parseSchema({
-            schema,
-            name: 'CreateBriefDto',
-            DTOs,
-        });
-
-        const expectedString = `
+    const expectedString = `
 export const aCreateBriefDtoAPI = (overrides?: Partial<CreateBriefDto>): CreateBriefDto => {
   return {
     title: 'title-createbriefdto',
@@ -451,49 +451,49 @@ export const aCreateBriefDtoAPI = (overrides?: Partial<CreateBriefDto>): CreateB
   };
 };
 `;
-        expect(result).toEqual(expectedString);
+    expect(result).toEqual(expectedString);
+});
+
+it('should generate PatchBriefDto mocks', async () => {
+    const DTOs = {
+        PriceTier: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Community', 'Bronze', 'Silver', 'Gold', 'Platinum'],
+            enum: ['Community', 'Bronze', 'Silver', 'Gold', 'Platinum'],
+        },
+    };
+    const schema = {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+            requestedDelivery: {
+                type: 'string',
+                format: 'date-time',
+                nullable: true,
+            },
+            tiers: {
+                type: 'array',
+                nullable: true,
+                items: {
+                    nullable: true,
+                    oneOf: [
+                        {
+                            $ref: '#/components/schemas/PriceTier',
+                        },
+                    ],
+                },
+            },
+        },
+    };
+
+    const result = parseSchema({
+        schema,
+        name: 'PatchBriefDto',
+        DTOs,
     });
 
-    it('should generate PatchBriefDto mocks', async () => {
-        const DTOs = {
-            PriceTier: {
-                type: 'string',
-                description: '',
-                'x-enumNames': ['Community', 'Bronze', 'Silver', 'Gold', 'Platinum'],
-                enum: ['Community', 'Bronze', 'Silver', 'Gold', 'Platinum'],
-            },
-        };
-        const schema = {
-            type: 'object',
-            additionalProperties: false,
-            properties: {
-                requestedDelivery: {
-                    type: 'string',
-                    format: 'date-time',
-                    nullable: true,
-                },
-                tiers: {
-                    type: 'array',
-                    nullable: true,
-                    items: {
-                        nullable: true,
-                        oneOf: [
-                            {
-                                $ref: '#/components/schemas/PriceTier',
-                            },
-                        ],
-                    },
-                },
-            },
-        };
-
-        const result = parseSchema({
-            schema,
-            name: 'PatchBriefDto',
-            DTOs,
-        });
-
-        const expectedString = `
+    const expectedString = `
 export const aPatchBriefDtoAPI = (overrides?: Partial<PatchBriefDto>): PatchBriefDto => {
   return {
     requestedDelivery: '2019-06-10T06:20:01.389Z',
@@ -502,39 +502,39 @@ export const aPatchBriefDtoAPI = (overrides?: Partial<PatchBriefDto>): PatchBrie
   };
 };
 `;
-        expect(result).toEqual(expectedString);
-    });
+    expect(result).toEqual(expectedString);
+});
 
-    it('should generate array of enum mocks', async () => {
-        const DTOs = {
-            PriceTier: {
-                type: 'string',
-                description: '',
-                'x-enumNames': ['Community', 'Bronze', 'Silver', 'Gold', 'Platinum'],
-                enum: ['Community', 'Bronze', 'Silver', 'Gold', 'Platinum'],
-            },
-        };
-        const schema = {
-            type: 'object',
-            additionalProperties: false,
-            properties: {
-                tiers: {
-                    type: 'array',
-                    nullable: true,
-                    items: {
-                        $ref: '#/components/schemas/PriceTier',
-                    },
+it('should generate array of enum mocks', async () => {
+    const DTOs = {
+        PriceTier: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Community', 'Bronze', 'Silver', 'Gold', 'Platinum'],
+            enum: ['Community', 'Bronze', 'Silver', 'Gold', 'Platinum'],
+        },
+    };
+    const schema = {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+            tiers: {
+                type: 'array',
+                nullable: true,
+                items: {
+                    $ref: '#/components/schemas/PriceTier',
                 },
             },
-        };
+        },
+    };
 
-        const result = parseSchema({
-            schema,
-            name: 'PatchBriefDto',
-            DTOs,
-        });
+    const result = parseSchema({
+        schema,
+        name: 'PatchBriefDto',
+        DTOs,
+    });
 
-        const expectedString = `
+    const expectedString = `
 export const aPatchBriefDtoAPI = (overrides?: Partial<PatchBriefDto>): PatchBriefDto => {
   return {
     tiers: ['Community'],
@@ -542,37 +542,37 @@ export const aPatchBriefDtoAPI = (overrides?: Partial<PatchBriefDto>): PatchBrie
   };
 };
 `;
-        expect(result).toEqual(expectedString);
-    });
+    expect(result).toEqual(expectedString);
+});
 
-    it('should generate mocks for CreateServiceDto', async () => {
-        const DTOs = {
-            ServiceTypeBasicDto: {
-                type: 'object',
-                properties: {
-                    code: {
-                        type: 'string',
-                        minLength: 1,
-                    },
-                },
-            },
-        };
-        const schema = {
+it('should generate mocks for CreateServiceDto', async () => {
+    const DTOs = {
+        ServiceTypeBasicDto: {
             type: 'object',
             properties: {
-                serviceType: {
-                    $ref: '#/components/schemas/ServiceTypeBasicDto',
+                code: {
+                    type: 'string',
+                    minLength: 1,
                 },
             },
-        };
+        },
+    };
+    const schema = {
+        type: 'object',
+        properties: {
+            serviceType: {
+                $ref: '#/components/schemas/ServiceTypeBasicDto',
+            },
+        },
+    };
 
-        const result = parseSchema({
-            schema,
-            name: 'CreateServiceDto',
-            DTOs,
-        });
+    const result = parseSchema({
+        schema,
+        name: 'CreateServiceDto',
+        DTOs,
+    });
 
-        const expectedString = `
+    const expectedString = `
 export const aCreateServiceDtoAPI = (overrides?: Partial<CreateServiceDto>): CreateServiceDto => {
   return {
     serviceType: overrides?.serviceType || aServiceTypeBasicDtoAPI(),
@@ -580,42 +580,42 @@ export const aCreateServiceDtoAPI = (overrides?: Partial<CreateServiceDto>): Cre
   };
 };
 `;
-        expect(result).toEqual(expectedString);
-    });
+    expect(result).toEqual(expectedString);
+});
 
-    it('should properly parse schemas', async () => {
-        fs.existsSync.mockReturnValue(false);
-        fs.mkdirSync.mockReturnValue(false);
+it('should properly parse schemas', async () => {
+    fs.existsSync.mockReturnValue(false);
+    fs.mkdirSync.mockReturnValue(false);
 
-        const json = {
-            paths: {},
-            servers: {},
-            info: {},
-            components: {
-                schemas: {
-                    One: {
-                        type: 'object',
-                        properties: {
-                            name: {
-                                type: 'string',
-                            },
+    const json = {
+        paths: {},
+        servers: {},
+        info: {},
+        components: {
+            schemas: {
+                One: {
+                    type: 'object',
+                    properties: {
+                        name: {
+                            type: 'string',
                         },
                     },
-                    Two: {
-                        type: 'object',
-                        properties: {
-                            name: {
-                                type: 'number',
-                            },
+                },
+                Two: {
+                    type: 'object',
+                    properties: {
+                        name: {
+                            type: 'number',
                         },
                     },
                 },
             },
-        };
+        },
+    };
 
-        const result = parseSchemas({ json, swaggerVersion: 3 });
+    const result = parseSchemas({ json, swaggerVersion: 3 });
 
-        const expectedString = `
+    const expectedString = `
 export const anOneAPI = (overrides?: Partial<One>): One => {
   return {
     name: 'name-one',
@@ -631,45 +631,45 @@ export const aTwoAPI = (overrides?: Partial<Two>): Two => {
 };
  
 `;
-        expect(result).toEqual(expectedString);
-    });
+    expect(result).toEqual(expectedString);
+});
 
-    it('should convert to mocks hole json object', async () => {
-        const json = {
-            paths: {},
-            servers: {},
-            info: {},
-            components: {
-                schemas: {
-                    One: {
-                        type: 'object',
-                        properties: {
-                            name: {
-                                type: 'string',
-                            },
+it('should convert to mocks hole json object', async () => {
+    const json = {
+        paths: {},
+        servers: {},
+        info: {},
+        components: {
+            schemas: {
+                One: {
+                    type: 'object',
+                    properties: {
+                        name: {
+                            type: 'string',
                         },
                     },
-                    Two: {
-                        type: 'object',
-                        properties: {
-                            name: {
-                                type: 'number',
-                            },
+                },
+                Two: {
+                    type: 'object',
+                    properties: {
+                        name: {
+                            type: 'number',
                         },
                     },
                 },
             },
-        };
+        },
+    };
 
-        const result = await convertToMocks({
-            json,
-            fileName: 'doesnt matter',
-            folderPath: './someFolder',
-            typesPath: './pathToTypes',
-            swaggerVersion: 3,
-        });
+    const result = await convertToMocks({
+        json,
+        fileName: 'doesnt matter',
+        folderPath: './someFolder',
+        typesPath: './pathToTypes',
+        swaggerVersion: 3,
+    });
 
-        const expectedString = `/* eslint-disable @typescript-eslint/no-use-before-define */
+    const expectedString = `/* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import {One, Two} from './pathToTypes';
 
@@ -688,6 +688,127 @@ export const aTwoAPI = (overrides?: Partial<Two>): Two => {
 };
  
 `;
-        expect(result).toEqual(expectedString);
+    expect(result).toEqual(expectedString);
+});
+
+it('should generate mocks for "MemberEmailDto" (email property)', async () => {
+    const json = {
+        paths: {},
+        servers: {},
+        info: {},
+        components: {
+            schemas: {
+                MemberEmailDto: {
+                    type: 'object',
+                    additionalProperties: false,
+                    properties: {
+                        email: {
+                            type: 'string',
+                            format: 'email',
+                            nullable: true,
+                        },
+                    },
+                },
+            },
+        },
+    };
+    const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {MemberEmailDto} from './pathToTypes';
+
+export const aMemberEmailDtoAPI = (overrides?: Partial<MemberEmailDto>): MemberEmailDto => {
+  return {
+    email: 'Destiney.Raynor@Charlie.biz',
+  ...overrides,
+  };
+};
+ 
+`;
+
+    const result = await convertToMocks({
+        json,
+        fileName: "doesn't matter",
+        folderPath: './someFolder',
+        typesPath: './pathToTypes',
+        swaggerVersion: 3,
     });
+
+    expect(result).toEqual(expected);
+});
+
+it('should generate mocks for "Comment" (duration property)', async () => {
+    const json = {
+        paths: {},
+        servers: {},
+        info: {},
+        components: {
+            schemas: {
+                Comment: {
+                    type: "object",
+                    additionalProperties: false,
+                    properties: {
+                        id: {
+                            type: "string",
+                            format: "guid"
+                        },
+                        message: {
+                            type: "string",
+                            nullable: true
+                        },
+                        userId: {
+                            type: "string",
+                            format: "guid"
+                        },
+                        annotationTime: {
+                            type: "string",
+                            format: "time-span",
+                            nullable: true
+                        },
+                        annotationDuration: {
+                            type: "string",
+                            format: "time-span",
+                            nullable: true
+                        },
+                        creationTime: {
+                            type: "string",
+                            format: "date-time"
+                        },
+                        lastModifiedTime: {
+                            type: "string",
+                            format: "date-time"
+                        }
+                    }
+                },
+            },
+        },
+    };
+
+    const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {Comment} from './pathToTypes';
+
+export const aCommentAPI = (overrides?: Partial<Comment>): Comment => {
+  return {
+    id: '6046ffb2-6bf2-4352-8bd1-399138ba33c0',
+  message: 'message-comment',
+  userId: '768bbcf6-0bde-4398-9859-3e2eb664e6f7',
+  annotationTime: '2019-06-10T06:20:01.389Z',
+  annotationDuration: '2019-06-10T06:20:01.389Z',
+  creationTime: '2019-06-10T06:20:01.389Z',
+  lastModifiedTime: '2019-06-10T06:20:01.389Z',
+  ...overrides,
+  };
+};
+ 
+`
+
+    const result = await convertToMocks({
+        json,
+        fileName: "doesn't matter",
+        folderPath: './someFolder',
+        typesPath: './pathToTypes',
+        swaggerVersion: 3,
+    });
+
+    expect(result).toEqual(expected);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,17 +2,17 @@
 # yarn lockfile v1
 
 
-"@auto-it/bot-list@^9.47.0":
-  version "9.47.0"
-  resolved "https://registry.yarnpkg.com/@auto-it/bot-list/-/bot-list-9.47.0.tgz#c08cd67002f5acd7f686a4108c9cdc99770807c3"
-  integrity sha512-Zo6OFR5aSpU/7f7nv/e3EF1Or0v1BUaJaGYIVCGMD7yJrWc2X7SR5bZ+j0HojaZwvLej8qELNB4ZUV+SXJFhRA==
+"@auto-it/bot-list@^9.49.1":
+  version "9.49.1"
+  resolved "https://registry.yarnpkg.com/@auto-it/bot-list/-/bot-list-9.49.1.tgz#bf0b00261a1a9d0ed584bbf713dd266bc5824344"
+  integrity sha512-7Glh03SdfFzfuqUjphF24RHuj4Jjzf5RdpeIvzAmKfKi84k9WTJLX3PPv0cvDX1NorLRTDJTjexX/IUy+64aLQ==
 
-"@auto-it/core@^9.47.0":
-  version "9.47.0"
-  resolved "https://registry.yarnpkg.com/@auto-it/core/-/core-9.47.0.tgz#6609e5f77255300fff4f2609eff8caa3857bda60"
-  integrity sha512-C7kLRrnTwWB9lBiwTAJLXr3wvhg/+zchC7bCOC8FAtIwZxWV/s0peFKaN0RAKerxGzO940yciNzkYKVRvG9EFQ==
+"@auto-it/core@^9.49.1":
+  version "9.49.1"
+  resolved "https://registry.yarnpkg.com/@auto-it/core/-/core-9.49.1.tgz#7a9725f5f36c0b3f4a97617dbb514cd3ba2c9754"
+  integrity sha512-IVkrn/cRyJh8+JtefbmojZ9X56oTE21KSwyPZiG6eexpFiGorh4QZQYsGl5dck3Iq8bW2L1mpt0K719lP23FfA==
   dependencies:
-    "@auto-it/bot-list" "^9.47.0"
+    "@auto-it/bot-list" "^9.49.1"
     "@octokit/graphql" "^4.4.0"
     "@octokit/plugin-enterprise-compatibility" "^1.2.2"
     "@octokit/plugin-retry" "^3.0.1"
@@ -48,12 +48,12 @@
     typescript-memoize "^1.0.0-alpha.3"
     url-join "^4.0.0"
 
-"@auto-it/npm@^9.47.0":
-  version "9.47.0"
-  resolved "https://registry.yarnpkg.com/@auto-it/npm/-/npm-9.47.0.tgz#1c8d87c5488569c0a8a6468315e87b10c8797187"
-  integrity sha512-Gy5dIMDto3BaZVGb78fr5Il4JABbQM7r3XrazC46JTKnSN13y2IpFqmNG4/inBCY2PD5hcVlDPKwqXlUc0SKdg==
+"@auto-it/npm@^9.49.1":
+  version "9.49.1"
+  resolved "https://registry.yarnpkg.com/@auto-it/npm/-/npm-9.49.1.tgz#e71ef0b3289bfe30a9e5bbb252b46a44b75b02e6"
+  integrity sha512-ZxPwTk8KUZHDv41BKoTrxp+5Q3B17mhXqWHxlJTqBjiKr0hJec6JGi9yFVWBEr6XvbVyIzSTscJFZMInkQP0cQ==
   dependencies:
-    "@auto-it/core" "^9.47.0"
+    "@auto-it/core" "^9.49.1"
     await-to-js "^2.1.1"
     env-ci "^5.0.1"
     fp-ts "^2.5.3"
@@ -68,12 +68,12 @@
     url-join "^4.0.0"
     user-home "^2.0.0"
 
-"@auto-it/released@^9.47.0":
-  version "9.47.0"
-  resolved "https://registry.yarnpkg.com/@auto-it/released/-/released-9.47.0.tgz#f8baf8c06f81329627188d44771a00d4f011bf9a"
-  integrity sha512-YQfMT21ZY3pEJUu46mZP4mJWZ1X1RbFX15ObvkNNa5/CixIGPbGTprvS/cmnEm8m32DS/db1eQ3OcHfqdnaeLg==
+"@auto-it/released@^9.49.1":
+  version "9.49.1"
+  resolved "https://registry.yarnpkg.com/@auto-it/released/-/released-9.49.1.tgz#8161396f4acdf069fbf5dc589127ee0018cc60c0"
+  integrity sha512-811sHa/a/LLjxSFkebO7TEOH42QsQ/OEWoB+3YFYrPXqrAox58BOw4slt7dzfS2UpXr6F5U0kmi7ojgDYggTUw==
   dependencies:
-    "@auto-it/core" "^9.47.0"
+    "@auto-it/core" "^9.49.1"
     deepmerge "^4.0.0"
     fp-ts "^2.5.3"
     io-ts "^2.1.2"
@@ -668,6 +668,11 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
+"@types/indefinite@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@types/indefinite/-/indefinite-2.3.0.tgz#a01558845cd8bf759c5564b9d762b0806432742d"
+  integrity sha512-vUbzBClWsKK3ET0bk8P3AaFaSpAObT3FeQqJcAM1tl6QSjDvK1si2Ky26hz4igRfu3l78nna9GXdVIxEpX9M+w==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -998,14 +1003,14 @@ author-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/author-regex/-/author-regex-1.0.0.tgz#d08885be6b9bbf9439fe087c76287245f0a81450"
   integrity sha1-0IiFvmubv5Q5/gh8dihyRfCoFFA=
 
-auto@^9.25.1:
-  version "9.47.0"
-  resolved "https://registry.yarnpkg.com/auto/-/auto-9.47.0.tgz#10fcb452e2a790f47ef8e20a32796c8d80d35250"
-  integrity sha512-BiF1crto0KU0TN5YbOWL52CWsLZUj0N2fqy0gBaKFmUxEPql6Tlam+teqtTzLOFv/6ew1Z8Ot4sdXu7UZNweyQ==
+auto@^9.47.0:
+  version "9.49.1"
+  resolved "https://registry.yarnpkg.com/auto/-/auto-9.49.1.tgz#4a7d79616e9d85f9e51c2b7d503976aebee1596f"
+  integrity sha512-iYEWKwr8XX3hbIzqw42coiiPnEgNYjq8RBVrGZeh2m28SE+F/mMWmTtmXlPuVcvVWUQ+Gl3W7XCu78pOXL9I/w==
   dependencies:
-    "@auto-it/core" "^9.47.0"
-    "@auto-it/npm" "^9.47.0"
-    "@auto-it/released" "^9.47.0"
+    "@auto-it/core" "^9.49.1"
+    "@auto-it/npm" "^9.49.1"
+    "@auto-it/released" "^9.49.1"
     await-to-js "^2.1.1"
     chalk "^4.0.0"
     command-line-application "^0.10.1"
@@ -2508,6 +2513,11 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
+
+indefinite@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/indefinite/-/indefinite-2.3.2.tgz#e3c5163ae60c2b810b3b5ffc57e8d57c52859d55"
+  integrity sha512-+RqxIRGrhBOfV8KONFaAuNvx1pg6Qh+Ge9w+15TI2LRfVu3aSf5bj9w3OU2GT3k8H13/7Q+C9+pek0jjYby3ZA==
 
 inflight@^1.0.4:
   version "1.0.6"


### PR DESCRIPTION
## Description
Fixed codegen for DTOs that have email props - previous generated values were "undefined";
Fixed codegen for DTOs that have "time-span" prop types - previous generated values were "undefined";
Added new tests

## Screenshots/Videos
![tests](https://user-images.githubusercontent.com/22501553/88898410-5ba7d400-d255-11ea-99ab-878e3575f4df.jpg)

## Checklist
- [x] Contains no duplicate/temporary code
- [x] Contains no sensitive information
- [ ] Error handling added
- [x] Unit tests added

## Related PRs:
- fix multiple extends mocks codegen (part 2): https://github.com/LandrAudio/openapi-codegen-typescript/pull/10
- refactor (part 3): https://github.com/LandrAudio/openapi-codegen-typescript/pull/11

## JIRA Issue
https://mixgenius.atlassian.net/browse/PROJ-4210