### PR TITLE
refactor(mocks-codegen): mocks converter and MockGenerateHelper refactor (part 3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
         "typescript": "3.8.2"
     },
     "dependencies": {
+        "@types/indefinite": "^2.3.0",
         "casual": "1.6.2",
+        "indefinite": "^2.3.2",
         "node-fetch": "2.6.0"
     },
     "files": [

--- a/src/MockGenerateHelper.ts
+++ b/src/MockGenerateHelper.ts
@@ -1,0 +1,210 @@
+import casual from 'casual';
+import { hashedString } from './shared';
+import {
+    ConvertRefType,
+    DataTypes,
+    GetArrayOfItemsMockProps,
+    GetArrayOfOneOfMockProps,
+    GetNumberMockProps,
+    GetRefTypeMockProps,
+    GetStringMockProps,
+    MockArrayProps,
+    PropertyNames,
+    StringFormats,
+    SwaggerProps,
+} from './types';
+
+export class MockGenerateHelper {
+    private casual: any;
+
+    constructor(casual: any) {
+        this.casual = casual;
+    }
+
+    getStringMock({ name, propertyName, format }: GetStringMockProps): MockArrayProps {
+        this.casual.seed(hashedString(name + propertyName));
+        let value;
+
+        if (!format) {
+            // simple string
+            value = `'${propertyName}-${name.toLowerCase()}'`;
+        } else if (format === StringFormats.Guid || propertyName === PropertyNames.Id) {
+            value = `'${this.casual.uuid}'`;
+        } else if (format === StringFormats.DateTime || format === StringFormats.TimeSpan) {
+            value = `'2019-06-10T06:20:01.389Z'`;
+        } else if (format === StringFormats.Date) {
+            value = `'2019-06-10'`;
+        } else if (format === StringFormats.Email) {
+            value = `'${this.casual.email}'`;
+        }
+
+        if (!value) {
+            value = 'TODO: FIX';
+        }
+
+        return {
+            propertyName,
+            value,
+        };
+    }
+
+    /**
+     * Returns mock data for types 'integer' and 'double'
+     * @param propertyName
+     * @param type
+     * @param minimum
+     * @param maximum
+     */
+    getNumberMock({ propertyName, type, minimum, maximum }: GetNumberMockProps): MockArrayProps {
+        return {
+            propertyName,
+            value:
+                type === DataTypes.Integer
+                    ? casual.integer(minimum || 0, maximum || 30)
+                    : casual.double(minimum || 0, maximum || 30),
+        };
+    }
+
+    /**
+     * Returns mock data for type 'boolean'
+     * @param propertyName
+     */
+    getBooleanMock(propertyName: string): MockArrayProps {
+        return {
+            propertyName,
+            value: true,
+        };
+    }
+
+    /**
+     * Returns mock data for array of values.
+     * Could return array of DTOs, Enums, Strings, Doubles...
+     * @param propertyName
+     * @param items
+     * @param DTOs
+     * @param parseRefType
+     */
+    getArrayOfItemsMock({ propertyName, items, DTOs, parseRefType }: GetArrayOfItemsMockProps): MockArrayProps {
+        let result = {
+            propertyName: `TODO: FIX ERROR in ${propertyName}`,
+            value: 'NULL',
+        } as MockArrayProps;
+
+        if (items[SwaggerProps.$ref]) {
+            const refType = items[SwaggerProps.$ref].split('/');
+
+            const ref = parseRefType(refType);
+
+            const schema = DTOs[ref];
+            if (schema && schema.enum) {
+                result = { propertyName, value: `['${schema.enum[0]}']` };
+            } else {
+                result = MockGenerateHelper.convertRefType({ propertyName, ref, isArray: true });
+            }
+        } else {
+            const type = items.oneOf ? parseRefType(items.oneOf[0][SwaggerProps.$ref].split('/')) : items.type;
+
+            if (items.oneOf) {
+                const schema = DTOs[type];
+                if (schema && schema.enum) {
+                    result = { propertyName, value: `['${schema.enum[0]}']` };
+                }
+            } else {
+                if (items.type === DataTypes.Number) {
+                    result = { propertyName, value: `[${casual.double()},${casual.double()}]` };
+                } else {
+                    result = { propertyName, value: `['${casual.word}']` };
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Return one element of Enum or DTO
+     * @param propertyName
+     * @param oneOf
+     * @param DTOs
+     * @param parseRefType
+     */
+    getDtoMock({ propertyName, oneOf, DTOs, parseRefType }: GetArrayOfOneOfMockProps): MockArrayProps {
+        const refType = oneOf[0][SwaggerProps.$ref].split('/');
+
+        const ref = parseRefType(refType);
+
+        const schema = DTOs[ref];
+        if (schema && schema.enum) {
+            return { propertyName, value: `'${schema.enum[0]}'` };
+        } else {
+            return MockGenerateHelper.convertRefType({ propertyName, ref });
+        }
+    }
+
+    getRefTypeMock = ({ $ref, propertyName, DTOs, parseRefType }: GetRefTypeMockProps): MockArrayProps => {
+        let result = {
+            propertyName: `TODO: FIX ERROR in ${propertyName} ref:${$ref}`,
+            value: 'NULL',
+        } as MockArrayProps;
+
+        const refType = $ref.split('/');
+
+        const ref = parseRefType(refType);
+
+        const schema = DTOs[ref];
+        if (schema && schema.enum) {
+            result = { propertyName, value: `'${schema.enum[0]}'` };
+        } else if (schema) {
+            result = MockGenerateHelper.convertRefType({ propertyName, ref });
+        }
+
+        return result;
+    };
+
+    static getIsAnOrA = (word: string) => {
+        const symbol = word[0].toLowerCase();
+        const isAn =
+            symbol === 'a' || symbol === 'e' || symbol === 'i' || symbol === 'o' || symbol === 'y' || symbol === 'u';
+
+        return isAn ? 'an' : 'a';
+    };
+
+    static joinVariableNamesAndValues = (varNamesAndValues: Array<MockArrayProps>): string =>
+        varNamesAndValues.map((mock: MockArrayProps) => `  ${mock.propertyName}: ${mock.value},`).join('\n');
+
+    static getMockTemplateString = ({ typeName, varNamesAndValues }: any) => {
+        const prefix = MockGenerateHelper.getIsAnOrA(typeName);
+        const joinedVarsAndNames = MockGenerateHelper.joinVariableNamesAndValues(varNamesAndValues);
+        return `
+export const ${prefix}${typeName}API = (overrides?: Partial<${typeName}>): ${typeName} => {
+  return {
+  ${joinedVarsAndNames}
+  ...overrides,
+  };
+};
+`;
+    };
+
+    static convertRefType = ({
+        propertyName,
+        ref,
+        isArray = false,
+    }: ConvertRefType): {
+        propertyName: string;
+        value: any;
+    } => {
+        const aOrAn = MockGenerateHelper.getIsAnOrA(ref);
+
+        let value;
+        if (isArray) {
+            value = `overrides?.${propertyName} || [${aOrAn}${ref}API()]`;
+        } else {
+            value = `overrides?.${propertyName} || ${aOrAn}${ref}API()`;
+        }
+
+        return {
+            propertyName,
+            value,
+        };
+    };
+}

--- a/src/mockConverter.ts
+++ b/src/mockConverter.ts
@@ -1,77 +1,13 @@
-import {
-    ConvertToMocksProps,
-    DataTypes,
-    GetSchemasProps,
-    MockArrayProps,
-    PropertyNames,
-    StringFormats,
-    SwaggerProps,
-} from './types';
+import { ConvertToMocksProps, DataTypes, GetSchemasProps, MockArrayProps, SwaggerProps } from './types';
 import { getSchemaProperties, getSchemas, hashedString, writeToFile } from './shared';
 import casual from 'casual';
+import { MockGenerateHelper } from './MockGenerateHelper';
 
 const parseRefType = (refType: string[]): string => refType[refType.length - 1];
 
-const getVariables = (varNamesAndValues: Array<MockArrayProps>) =>
-    varNamesAndValues.map((mock: MockArrayProps) => `  ${mock.propertyName}: ${mock.value},`).join('\n');
-
-const isAn = (word: string) => {
-    const symbol = word[0].toLowerCase();
-    const isAn =
-        symbol === 'a' || symbol === 'e' || symbol === 'i' || symbol === 'o' || symbol === 'y' || symbol === 'u';
-
-    return isAn ? 'an' : 'a';
-};
-
-const getMockTemplateString = ({ typeName, varNamesAndValues }: any) => `
-export const ${isAn(typeName)}${typeName}API = (overrides?: Partial<${typeName}>): ${typeName} => {
-  return {
-  ${getVariables(varNamesAndValues)}
-  ...overrides,
-  };
-};
-`;
-
-function getStringFakeValue({
-    name,
-    propertyName,
-    format,
-    minLength,
-    maxLength,
-}: {
-    name: string;
-    propertyName: string;
-    format: string;
-    minLength: number;
-    maxLength: number;
-}) {
-    casual.seed(hashedString(name + propertyName));
-
-    let value;
-
-    if (!format) {
-        // simple string
-        value = `'${propertyName}-${name.toLowerCase()}'`;
-    } else if (format === StringFormats.Guid || propertyName === PropertyNames.Id) {
-        value = `'${casual.uuid}'`;
-    } else if (format === StringFormats.DateTime || format === StringFormats.TimeSpan) {
-        value = `'2019-06-10T06:20:01.389Z'`;
-    } else if (format === StringFormats.Date) {
-        value = `'2019-06-10'`;
-    } else if (format === StringFormats.Email) {
-        value = `'${casual.email}'`;
-    }
-
-    if (!value) {
-        value = 'TODO: FIX';
-    }
-
-    return value;
-}
-
-const getIsSchemaContainsAllOfArray = (schema:any) => {
+const getIsSchemaContainsAllOfArray = (schema: any) => {
     return schema && schema[SwaggerProps.AllOf] && Array.isArray(schema[SwaggerProps.AllOf]);
-}
+};
 
 /**
  * Get all interfaces that this schema exteds
@@ -79,7 +15,6 @@ const getIsSchemaContainsAllOfArray = (schema:any) => {
  * @param DTOs all DTOs
  */
 export const getSchemaInterfaces = (schema: any, DTOs: any): Array<string> | undefined => {
-
     if (getIsSchemaContainsAllOfArray(schema)) {
         const result = [] as Array<string>;
 
@@ -146,26 +81,6 @@ export const combineProperties = ({ schema, schemas, interfaces }: CombineProper
     return Object.assign({}, schema);
 };
 
-export const convertRefType = ({
-    propertyName,
-    ref,
-    isArray = false,
-}: {
-    propertyName: string;
-    ref: any;
-    isArray?: boolean;
-}) => {
-    if (isArray) {
-        return { propertyName, value: ownPropString(propertyName, `[${isAn(ref)}${ref}API()]`) };
-    } else {
-        return { propertyName, value: ownPropString(propertyName, `${isAn(ref)}${ref}API()`) };
-    }
-};
-
-const ownPropString = (propName: string, result: string) => {
-    return `overrides?.${propName} || ${result}`;
-};
-
 interface ParseSchemaProps {
     schema: any;
     /**
@@ -180,7 +95,6 @@ interface ParseSchemaProps {
 }
 
 export const parseSchema = ({ schema, name, DTOs }: ParseSchemaProps) => {
-
     const parseSwaggerJsonObject = (obj: any, interfaces?: Array<string>): string => {
         if (interfaces) {
             obj = combineProperties({ schema: obj, schemas: DTOs, interfaces });
@@ -206,98 +120,60 @@ export const parseSchema = ({ schema, name, DTOs }: ParseSchemaProps) => {
                 } = props;
                 casual.seed(hashedString(name + propertyName));
 
-                    if (type === DataTypes.String) {
-                        mocks.push({
-                            propertyName,
-                            value: getStringFakeValue({ name, propertyName, format, minLength, maxLength }),
-                        });
-                    }
+                const mockGenerator = new MockGenerateHelper(casual);
 
-                    if (type === DataTypes.Integer || type === DataTypes.Number) {
-                        mocks.push({
-                            propertyName,
-                            value:
-                                type === DataTypes.Integer
-                                    ? casual.integer(minimum || 0, maximum || 30)
-                                    : casual.double(minimum || 0, maximum || 30),
-                        });
-                    }
+                if (type === DataTypes.String) {
+                    const stringMock = mockGenerator.getStringMock({
+                        name,
+                        propertyName,
+                        format,
+                        minLength,
+                        maxLength,
+                    });
+                    mocks.push(stringMock);
+                }
 
-                    if (type === DataTypes.Boolean) {
-                        mocks.push({ propertyName, value: true });
-                    }
+                if (type === DataTypes.Integer || type === DataTypes.Number) {
+                    const numberMock = mockGenerator.getNumberMock({ propertyName, type, minimum, maximum });
+                    mocks.push(numberMock);
+                }
 
-                    if (type === DataTypes.Array && items) {
-                        if (items[SwaggerProps.$ref]) {
-                            const refType = items[SwaggerProps.$ref].split('/');
+                if (type === DataTypes.Boolean) {
+                    const boolMock = mockGenerator.getBooleanMock(propertyName);
+                    mocks.push(boolMock);
+                }
 
-                            const ref = parseRefType(refType);
+                if (type === DataTypes.Array && items) {
+                    const arrayOfItemsMock = mockGenerator.getArrayOfItemsMock({
+                        propertyName,
+                        items,
+                        DTOs,
+                        parseRefType,
+                    });
+                    mocks.push(arrayOfItemsMock);
+                }
 
-                            const schema = DTOs[ref];
-                            if (schema && schema.enum) {
-                                mocks.push({ propertyName, value: `['${schema.enum[0]}']` });
-                            } else {
-                                mocks.push(convertRefType({ propertyName, ref, isArray: true }));
-                            }
-                        } else {
-                            const type = items.oneOf
-                                ? parseRefType(items.oneOf[0][SwaggerProps.$ref].split('/'))
-                                : items.type;
+                if (oneOf && Array.isArray(oneOf) && oneOf[0][SwaggerProps.$ref]) {
+                    const arrayOneOf = mockGenerator.getDtoMock({
+                        propertyName,
+                        oneOf,
+                        DTOs,
+                        parseRefType,
+                    });
+                    mocks.push(arrayOneOf);
+                }
 
-                            if (items.oneOf) {
-                                const schema = DTOs[type];
-                                if (schema && schema.enum) {
-                                    mocks.push({ propertyName, value: `['${schema.enum[0]}']` });
-                                }
-                            } else {
-                                if (items.type === DataTypes.Number) {
-                                    mocks.push({ propertyName, value: `[${casual.double()},${casual.double()}]` });
-                                } else {
-                                    mocks.push({ propertyName, value: `['${casual.word}']` });
-                                }
-                            }
-                        }
-                    }
-
-                    if (oneOf && Array.isArray(oneOf) && oneOf[0][SwaggerProps.$ref]) {
-                        const refType = oneOf[0][SwaggerProps.$ref].split('/');
-
-                        const ref = parseRefType(refType);
-
-                        const schema = DTOs[ref];
-                        if (schema && schema.enum) {
-                            mocks.push({ propertyName, value: `'${schema.enum[0]}'` });
-                        } else {
-                            mocks.push(convertRefType({ propertyName, ref }));
-                        }
-                    }
-
-                    if ($ref) {
-                        const refType = $ref.split('/');
-
-                        const ref = parseRefType(refType);
-
-                        const schema = DTOs[ref];
-                        if (schema && schema.enum) {
-                            mocks.push({ propertyName, value: `'${schema.enum[0]}'` });
-                        } else if (schema) {
-                            mocks.push(convertRefType({ propertyName, ref }));
-                        } else {
-                            mocks.push({
-                                propertyName: `ERROR in ${propertyName} ref:${ref}`,
-                                value: 'NULL',
-                            });
-                        }
-                    }
-                },
-            );
+                if ($ref) {
+                    const ref = mockGenerator.getRefTypeMock({ $ref, propertyName, DTOs, parseRefType });
+                    mocks.push(ref);
+                }
+            });
         }
 
-        return getMockTemplateString({ typeName: name, varNamesAndValues: mocks });
+        return MockGenerateHelper.getMockTemplateString({ typeName: name, varNamesAndValues: mocks });
     };
 
     if (schema[SwaggerProps.AllOf] && Array.isArray(schema[SwaggerProps.AllOf])) {
-
         const interfaces = getSchemaInterfaces(schema, DTOs);
 
         const object = schema.allOf.find((schema: any) => schema.type);
@@ -312,7 +188,7 @@ export const parseSchemas = ({ json, swaggerVersion }: GetSchemasProps) => {
     const DTOs = Object.keys(schemas);
 
     let resultString = '';
-    DTOs.map(dtoName => {
+    DTOs.forEach(dtoName => {
         try {
             const schema = schemas[dtoName];
             if (schema.type === DataTypes.Object || schema.allOf) {
@@ -348,7 +224,9 @@ export const convertToMocks = ({
     const importsDescription = `import {${imports}} from '${typesPath}';\n`;
 
     const result = parseSchemas({ json, swaggerVersion });
+
     const resultString = `${disableNoUse}${disableNoUsedVars}${importsDescription}${result}`;
+
     writeToFile({
         folderPath,
         fileName,

--- a/src/mockConverter.ts
+++ b/src/mockConverter.ts
@@ -1,17 +1,7 @@
-import {
-    ConvertToMocksProps,
-    DataTypes,
-    GetSchemasProps,
-    MockArrayProps,
-    PropertyNames,
-    StringFormats,
-    SwaggerProps,
-} from './types';
+import { ConvertToMocksProps, DataTypes, GetSchemasProps, MockArrayProps, SwaggerProps } from './types';
 import { getSchemaProperties, getSchemas, hashedString, writeToFile } from './shared';
 import casual from 'casual';
 import { MockGenerateHelper } from './MockGenerateHelper';
-
-const parseRefType = (refType: string[]): string => refType[refType.length - 1];
 
 const getIsSchemaContainsAllOfArray = (schema: any) => {
     return schema && schema[SwaggerProps.AllOf] && Array.isArray(schema[SwaggerProps.AllOf]);
@@ -34,7 +24,7 @@ export const getSchemaInterfaces = (schema: any, DTOs: any): Array<string> | und
                 Example: will return InviteMembersRequestDto
                 if "SomeDTo extends InviteMembersRequestDto"
                  */
-                const parsedRefType = parseRefType(refType);
+                const parsedRefType = MockGenerateHelper.parseRefType(refType);
 
                 // Repeat "getSchemaInterfaces" in cycle for inner interfaces
                 const newSchema = DTOs[parsedRefType];
@@ -165,7 +155,6 @@ export const parseSchema = ({ schema, name, DTOs }: ParseSchemaProps) => {
                         propertyName,
                         items,
                         DTOs,
-                        parseRefType,
                     });
                     mocks.push(arrayOfItemsMock);
                 }
@@ -175,13 +164,12 @@ export const parseSchema = ({ schema, name, DTOs }: ParseSchemaProps) => {
                         propertyName,
                         oneOf,
                         DTOs,
-                        parseRefType,
                     });
                     mocks.push(arrayOneOf);
                 }
 
                 if ($ref) {
-                    const ref = mockGenerator.getRefTypeMock({ $ref, propertyName, DTOs, parseRefType });
+                    const ref = mockGenerator.getRefTypeMock({ $ref, propertyName, DTOs });
                     mocks.push(ref);
                 }
             });

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,8 +52,14 @@ export enum ArrayAdditionalProps {
     UniqueItems = 'uniqueItems',
 }
 
-export interface ResultStringProps {
+export interface PropertyNameProp {
+    /**
+     * DTO\'s property name
+     */
     propertyName: string;
+}
+
+export interface ResultStringProps extends PropertyNameProp{
     nullable?: boolean;
 }
 
@@ -99,9 +105,39 @@ export interface ResultStringPropsForStringType extends ResultStringProps {
     maxLength?: number;
 }
 
-export interface MockArrayProps {
-    propertyName: string;
+export interface MockArrayProps extends PropertyNameProp{
     value: any;
+}
+
+export interface GetStringMockProps extends PropertyNameProp{
+    name: string;
+    format: string;
+    minLength: number;
+    maxLength: number;
+}
+
+export interface GetNumberMockProps extends PropertyNameProp {
+    type: DataTypes.Integer | DataTypes.Number;
+    minimum: number;
+    maximum: number;
+}
+
+export interface GetArrayOfItemsMockProps extends PropertyNameProp {
+    items: any;
+    DTOs: any;
+    parseRefType: Function;
+}
+
+export interface GetArrayOfOneOfMockProps extends PropertyNameProp {
+    oneOf: any;
+    DTOs: any;
+    parseRefType: Function;
+}
+
+export interface GetRefTypeMockProps extends PropertyNameProp {
+    $ref: string;
+    DTOs: any;
+    parseRefType: Function;
 }
 
 export interface ParseProps {
@@ -116,15 +152,10 @@ export interface SwaggerSchema {
     };
 }
 
-export interface Props {
-    swaggerJsonUrl: string;
+export interface ConvertRefType extends PropertyNameProp {
     /**
-     * Example: './src/types'
+     * Reference to another object DTO
      */
-    folderPath: string;
-    /**
-     * Example: swagger-profiles
-     */
-    fileName: string;
-    shouldGenerateMocks?: boolean;
+    ref: string;
+    isArray?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,19 +125,16 @@ export interface GetNumberMockProps extends PropertyNameProp {
 export interface GetArrayOfItemsMockProps extends PropertyNameProp {
     items: any;
     DTOs: any;
-    parseRefType: Function;
 }
 
 export interface GetArrayOfOneOfMockProps extends PropertyNameProp {
     oneOf: any;
     DTOs: any;
-    parseRefType: Function;
 }
 
 export interface GetRefTypeMockProps extends PropertyNameProp {
     $ref: string;
     DTOs: any;
-    parseRefType: Function;
 }
 
 export interface ParseProps {

--- a/tests/mockConverter.test.ts
+++ b/tests/mockConverter.test.ts
@@ -616,7 +616,7 @@ it('should properly parse schemas', async () => {
     const result = parseSchemas({ json, swaggerVersion: 3 });
 
     const expectedString = `
-export const anOneAPI = (overrides?: Partial<One>): One => {
+export const aOneAPI = (overrides?: Partial<One>): One => {
   return {
     name: 'name-one',
   ...overrides,
@@ -673,7 +673,7 @@ it('should convert to mocks hole json object', async () => {
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import {One, Two} from './pathToTypes';
 
-export const anOneAPI = (overrides?: Partial<One>): One => {
+export const aOneAPI = (overrides?: Partial<One>): One => {
   return {
     name: 'name-one',
   ...overrides,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,17 +2,17 @@
 # yarn lockfile v1
 
 
-"@auto-it/bot-list@^9.47.0":
-  version "9.47.0"
-  resolved "https://registry.yarnpkg.com/@auto-it/bot-list/-/bot-list-9.47.0.tgz#c08cd67002f5acd7f686a4108c9cdc99770807c3"
-  integrity sha512-Zo6OFR5aSpU/7f7nv/e3EF1Or0v1BUaJaGYIVCGMD7yJrWc2X7SR5bZ+j0HojaZwvLej8qELNB4ZUV+SXJFhRA==
+"@auto-it/bot-list@^9.49.1":
+  version "9.49.1"
+  resolved "https://registry.yarnpkg.com/@auto-it/bot-list/-/bot-list-9.49.1.tgz#bf0b00261a1a9d0ed584bbf713dd266bc5824344"
+  integrity sha512-7Glh03SdfFzfuqUjphF24RHuj4Jjzf5RdpeIvzAmKfKi84k9WTJLX3PPv0cvDX1NorLRTDJTjexX/IUy+64aLQ==
 
-"@auto-it/core@^9.47.0":
-  version "9.47.0"
-  resolved "https://registry.yarnpkg.com/@auto-it/core/-/core-9.47.0.tgz#6609e5f77255300fff4f2609eff8caa3857bda60"
-  integrity sha512-C7kLRrnTwWB9lBiwTAJLXr3wvhg/+zchC7bCOC8FAtIwZxWV/s0peFKaN0RAKerxGzO940yciNzkYKVRvG9EFQ==
+"@auto-it/core@^9.49.1":
+  version "9.49.1"
+  resolved "https://registry.yarnpkg.com/@auto-it/core/-/core-9.49.1.tgz#7a9725f5f36c0b3f4a97617dbb514cd3ba2c9754"
+  integrity sha512-IVkrn/cRyJh8+JtefbmojZ9X56oTE21KSwyPZiG6eexpFiGorh4QZQYsGl5dck3Iq8bW2L1mpt0K719lP23FfA==
   dependencies:
-    "@auto-it/bot-list" "^9.47.0"
+    "@auto-it/bot-list" "^9.49.1"
     "@octokit/graphql" "^4.4.0"
     "@octokit/plugin-enterprise-compatibility" "^1.2.2"
     "@octokit/plugin-retry" "^3.0.1"
@@ -48,12 +48,12 @@
     typescript-memoize "^1.0.0-alpha.3"
     url-join "^4.0.0"
 
-"@auto-it/npm@^9.47.0":
-  version "9.47.0"
-  resolved "https://registry.yarnpkg.com/@auto-it/npm/-/npm-9.47.0.tgz#1c8d87c5488569c0a8a6468315e87b10c8797187"
-  integrity sha512-Gy5dIMDto3BaZVGb78fr5Il4JABbQM7r3XrazC46JTKnSN13y2IpFqmNG4/inBCY2PD5hcVlDPKwqXlUc0SKdg==
+"@auto-it/npm@^9.49.1":
+  version "9.49.1"
+  resolved "https://registry.yarnpkg.com/@auto-it/npm/-/npm-9.49.1.tgz#e71ef0b3289bfe30a9e5bbb252b46a44b75b02e6"
+  integrity sha512-ZxPwTk8KUZHDv41BKoTrxp+5Q3B17mhXqWHxlJTqBjiKr0hJec6JGi9yFVWBEr6XvbVyIzSTscJFZMInkQP0cQ==
   dependencies:
-    "@auto-it/core" "^9.47.0"
+    "@auto-it/core" "^9.49.1"
     await-to-js "^2.1.1"
     env-ci "^5.0.1"
     fp-ts "^2.5.3"
@@ -68,12 +68,12 @@
     url-join "^4.0.0"
     user-home "^2.0.0"
 
-"@auto-it/released@^9.47.0":
-  version "9.47.0"
-  resolved "https://registry.yarnpkg.com/@auto-it/released/-/released-9.47.0.tgz#f8baf8c06f81329627188d44771a00d4f011bf9a"
-  integrity sha512-YQfMT21ZY3pEJUu46mZP4mJWZ1X1RbFX15ObvkNNa5/CixIGPbGTprvS/cmnEm8m32DS/db1eQ3OcHfqdnaeLg==
+"@auto-it/released@^9.49.1":
+  version "9.49.1"
+  resolved "https://registry.yarnpkg.com/@auto-it/released/-/released-9.49.1.tgz#8161396f4acdf069fbf5dc589127ee0018cc60c0"
+  integrity sha512-811sHa/a/LLjxSFkebO7TEOH42QsQ/OEWoB+3YFYrPXqrAox58BOw4slt7dzfS2UpXr6F5U0kmi7ojgDYggTUw==
   dependencies:
-    "@auto-it/core" "^9.47.0"
+    "@auto-it/core" "^9.49.1"
     deepmerge "^4.0.0"
     fp-ts "^2.5.3"
     io-ts "^2.1.2"
@@ -668,6 +668,11 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
+"@types/indefinite@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@types/indefinite/-/indefinite-2.3.0.tgz#a01558845cd8bf759c5564b9d762b0806432742d"
+  integrity sha512-vUbzBClWsKK3ET0bk8P3AaFaSpAObT3FeQqJcAM1tl6QSjDvK1si2Ky26hz4igRfu3l78nna9GXdVIxEpX9M+w==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -998,14 +1003,14 @@ author-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/author-regex/-/author-regex-1.0.0.tgz#d08885be6b9bbf9439fe087c76287245f0a81450"
   integrity sha1-0IiFvmubv5Q5/gh8dihyRfCoFFA=
 
-auto@^9.25.1:
-  version "9.47.0"
-  resolved "https://registry.yarnpkg.com/auto/-/auto-9.47.0.tgz#10fcb452e2a790f47ef8e20a32796c8d80d35250"
-  integrity sha512-BiF1crto0KU0TN5YbOWL52CWsLZUj0N2fqy0gBaKFmUxEPql6Tlam+teqtTzLOFv/6ew1Z8Ot4sdXu7UZNweyQ==
+auto@^9.47.0:
+  version "9.49.1"
+  resolved "https://registry.yarnpkg.com/auto/-/auto-9.49.1.tgz#4a7d79616e9d85f9e51c2b7d503976aebee1596f"
+  integrity sha512-iYEWKwr8XX3hbIzqw42coiiPnEgNYjq8RBVrGZeh2m28SE+F/mMWmTtmXlPuVcvVWUQ+Gl3W7XCu78pOXL9I/w==
   dependencies:
-    "@auto-it/core" "^9.47.0"
-    "@auto-it/npm" "^9.47.0"
-    "@auto-it/released" "^9.47.0"
+    "@auto-it/core" "^9.49.1"
+    "@auto-it/npm" "^9.49.1"
+    "@auto-it/released" "^9.49.1"
     await-to-js "^2.1.1"
     chalk "^4.0.0"
     command-line-application "^0.10.1"
@@ -2508,6 +2513,11 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
+
+indefinite@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/indefinite/-/indefinite-2.3.2.tgz#e3c5163ae60c2b810b3b5ffc57e8d57c52859d55"
+  integrity sha512-+RqxIRGrhBOfV8KONFaAuNvx1pg6Qh+Ge9w+15TI2LRfVu3aSf5bj9w3OU2GT3k8H13/7Q+C9+pek0jjYby3ZA==
 
 inflight@^1.0.4:
   version "1.0.6"


### PR DESCRIPTION
## Description
Separated mockConverter (main function) and new created MockGenerateHelper, added new type;
Spliced functionality of parsing and generating mock template string;

## Screenshots/Videos
![refactor](https://user-images.githubusercontent.com/22501553/88903303-25218780-d25c-11ea-925d-0f2898a1ab3d.jpg)

## Checklist
- [x] Contains no duplicate/temporary code
- [x] Contains no sensitive information
- [ ] Error handling added
- [x] Unit tests added

## Related PRs:
- fix 'email' and 'duration' mocks codegen (part 1): https://github.com/LandrAudio/openapi-codegen-typescript/pull/9
- fix multiple extends mocks codegen (part 2): https://github.com/LandrAudio/openapi-codegen-typescript/pull/10

## JIRA Issue
https://mixgenius.atlassian.net/browse/PROJ-4169