### PR TITLE
feat(override): add enum schema override and add property descriptions (part 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,56 +2,120 @@
 
 ## Installation
 
- - `yarn add -D openapi-codegen-typescript`
- - `npm install openapi-codegen-typescript --save-dev`
+- `yarn add -D openapi-codegen-typescript`
+- `npm install openapi-codegen-typescript --save-dev`
 
 ## Description
+
 What is this library for?
 
-  - For fetching json file (mostly for "Swagger json")
-  #### Example:
-  ```javascript
-  const { fetchSwaggerJsonFile } = require('openapi-codegen-typescript');  
-  
-  async function doSomething() {
-      const json = await fetchSwaggerJsonFile('https://custom/swagger.json');
-      console.log("Json Result", json)
-  }
-  ```
-  - For converting swagger.json file to typescript types
-  #### Example:
-  ```javascript
-    const { fetchSwaggerJsonFile, convertToTypes } = require('openapi-codegen-typescript');  
-    
-    async function doSomething() {
-        const json = await fetchSwaggerJsonFile('https://custom/swagger.json');
-        convertToTypes({ json, fileName: 'dtoAPI', folderPath: 'src/types/generated', swaggerVersion: 3 });
-    }
-  ```
+- For fetching json file (mostly for "Swagger json")
 
-This function ('doSomething()') fetches json file from urls, then converts json 
+#### Example:
+
+```javascript
+const { fetchSwaggerJsonFile } = require('openapi-codegen-typescript');
+
+async function doSomething() {
+  const json = await fetchSwaggerJsonFile('https://custom/swagger.json');
+  console.log('Json Result', json);
+}
+```
+
+- For converting swagger.json file to typescript types
+
+#### Example:
+
+```javascript
+const { fetchSwaggerJsonFile, convertToTypes } = require('openapi-codegen-typescript');
+
+async function doSomething() {
+  const json = await fetchSwaggerJsonFile('https://custom/swagger.json');
+  convertToTypes({ json, fileName: 'dtoAPI', folderPath: 'src/types/generated', swaggerVersion: 3 });
+}
+```
+
+This function ('doSomething()') fetches json file from urls, then converts json
 to typescript "types" and writes "types" to file ('src/types/generated/dtoAPI')
 If "swaggerVersion" will not be provided - it will be set to "3" by default.
-    
-  - For generating mock files that are using converted types
-  #### Example:
-  ```javascript
-      const { fetchSwaggerJsonFile, convertToTypes } = require('openapi-codegen-typescript');  
-      
-      async function doSomething() {
-          const json = await fetchSwaggerJsonFile('https://custom/swagger.json');
-          convertToMocks({
-                  json,
-                  fileName: 'dtoAPI',
-                  folderPath: 'src/mocks/generated',
-                  typesPath: '../../types/generated/dtoAPI',
-                  swaggerVersion: 3,
-              });
-      }
-  ```
+
+- For generating mock files that are using converted types
+
+#### Example:
+
+```javascript
+const { fetchSwaggerJsonFile, convertToTypes } = require('openapi-codegen-typescript');
+
+async function doSomething() {
+  const json = await fetchSwaggerJsonFile('https://custom/swagger.json');
+  convertToMocks({
+    json,
+    fileName: 'dtoAPI',
+    folderPath: 'src/mocks/generated',
+    typesPath: '../../types/generated/dtoAPI',
+    swaggerVersion: 3,
+  });
+}
+```
+
 This function ('doSomething()') fetches json file from urls, then converts json to "mocks" and writes "mocks" to file
- ('src/mocks/generated/dtoAPI') with imports from typescript types ('src/types/generated/dtoAPI') 
+('src/mocks/generated/dtoAPI') with imports from typescript types ('src/types/generated/dtoAPI')
 If "swaggerVersion" will not be provided - it will be set to "3" by default.
+
+## Overriding enum schema type
+
+You can override open-api enum types and mocks by specifying `overrideSchemas` prop.
+
+Let's imagine that we have this schema enum type in a json file:
+
+```json
+{
+  "SomeType": {
+    "type": "string",
+    "description": "",
+    "x-enumNames": ["Audio", "Video", "Image", "Text", "Raw"],
+    "enum": ["Audio", "Video", "Image", "Text", "Raw"]
+  }
+}
+```
+
+Overriding example:
+
+```javascript
+const { fetchSwaggerJsonFile, convertToTypes, convertToMocks } = require('openapi-codegen-typescript');
+
+const url = 'https://someLinkToSwagger/v2/swagger.json';
+
+async function main() {
+  const json = await fetchSwaggerJsonFile(url);
+  const overrideSchemas = [
+    {
+      ServiceOfferKind: {
+        type: 'string',
+        description: 'Warning! This type is overrided',
+        enum: ['masteringAndDistribution', 'video', 'samples', 'mastering', 'distribution', 'sessions'],
+      },
+    },
+  ];
+
+  convertToTypes({
+    json,
+    fileName: 'typesAPI',
+    folderPath: 'src/types/generated',
+    swaggerVersion: 3,
+    overrideSchemas,
+  });
+  convertToMocks({
+    json,
+    fileName: 'mocksAPI',
+    folderPath: 'src/mocks/generated',
+    typesPath: '../../types/generated/typesAPI',
+    swaggerVersion: 3,
+  });
+}
+
+main();
+```
 
 ## AllInOne Example:
 
@@ -61,15 +125,15 @@ const { fetchSwaggerJsonFile, convertToTypes, convertToMocks } = require('openap
 const petShopLink = 'https://petstore.swagger.io/v2/swagger.json';
 
 async function main() {
-    const json = await fetchSwaggerJsonFile(petShopLink);
-    convertToTypes({ json, fileName: 'typesAPI', folderPath: 'src/types/generated', swaggerVersion: 3 });
-    convertToMocks({
-        json,
-        fileName: 'mocksAPI',
-        folderPath: 'src/mocks/generated',
-        typesPath: '../../types/generated/typesAPI',
-        swaggerVersion: 3,
-    });
+  const json = await fetchSwaggerJsonFile(petShopLink);
+  convertToTypes({ json, fileName: 'typesAPI', folderPath: 'src/types/generated', swaggerVersion: 3 });
+  convertToMocks({
+    json,
+    fileName: 'mocksAPI',
+    folderPath: 'src/mocks/generated',
+    typesPath: '../../types/generated/typesAPI',
+    swaggerVersion: 3,
+  });
 }
 
 main();
@@ -78,11 +142,13 @@ main();
 ## Methods:
 
 #### fetchSwaggerJsonFile(url)
-`url`: `string` - url to swagger json file 
+
+`url`: `string` - url to swagger json file
 
 Returns a swagger json object;
 
 #### convertToTypes({ json, fileName, folderPath, swaggerVersion })
+
 `json`: `object` - swagger json data;
 `fileName`: `string` - name of the file, where typescript types data will be saved;
 `folderPath`: `string` - folder path the `fileName`, where typescript types data will be saved;
@@ -91,10 +157,11 @@ Returns a swagger json object;
 Returns `void`;
 
 #### convertToMocks({ json, fileName, folderPath, typesPath, swaggerVersion })
+
 `json`: `object` - swagger json data;
 `fileName`: `string` - name of the file, where mocks data will be saved;
 `folderPath`: `string` - folder path the `fileName`, where mocks data will be saved;
-`typesPath`: `string` - folder path to `types`, where typescript types data are saved. 
+`typesPath`: `string` - folder path to `types`, where typescript types data are saved.
 Path to `types` will be inserted to the type imports in generated mocks (generated -> import {...} from `typesPath`;);
 `swaggerVersion`: `number` - version of the swagger json file (specification);
 

--- a/src/MockGenerateHelper.ts
+++ b/src/MockGenerateHelper.ts
@@ -20,9 +20,9 @@ import {
 import { parseEnum } from './typesConverter';
 
 export class MockGenerateHelper {
-    private casual: any;
+    private casual: Casual.Generators & Casual.Casual;
 
-    constructor(casual: any) {
+    constructor(casual: Casual.Generators & Casual.Casual) {
         this.casual = casual;
     }
 
@@ -41,6 +41,8 @@ export class MockGenerateHelper {
             value = `'2019-06-10'`;
         } else if (format === StringFormats.Email) {
             value = `'${this.casual.email}'`;
+        } else if (format === StringFormats.Uri) {
+            value = `'${this.casual.url}'`;
         }
 
         if (!value) {

--- a/src/mockConverter.ts
+++ b/src/mockConverter.ts
@@ -1,4 +1,4 @@
-import { ConvertToMocksProps, DataTypes, GetSchemasProps, MockArrayProps, SwaggerProps } from './types';
+import { ConvertToMocksProps, DataTypes, EnumSchema, GetSchemasProps, MockArrayProps, SwaggerProps } from './types';
 import { getSchemaProperties, getSchemas, hashedString, writeToFile } from './shared';
 import casual from 'casual';
 import { MockGenerateHelper } from './MockGenerateHelper';
@@ -99,9 +99,10 @@ interface ParseSchemaProps {
      * All parsed DTOs from swagger json file
      */
     DTOs?: any;
+    overrideSchemas?: Array<EnumSchema>;
 }
 
-export const parseSchema = ({ schema, name, DTOs }: ParseSchemaProps) => {
+export const parseSchema = ({ schema, name, DTOs, overrideSchemas }: ParseSchemaProps) => {
     const parseSwaggerJsonObject = (obj: any, interfaces?: Array<string>): string => {
         if (interfaces) {
             obj = combineProperties({ schema: obj, schemas: DTOs, interfaces });
@@ -178,7 +179,13 @@ export const parseSchema = ({ schema, name, DTOs }: ParseSchemaProps) => {
 
                 if (xDictionaryKey && additionalProperties) {
                     mocks.push(
-                        mockGenerator.getDictionaryMock({ propertyName, xDictionaryKey, additionalProperties, DTOs }),
+                        mockGenerator.getDictionaryMock({
+                            propertyName,
+                            xDictionaryKey,
+                            additionalProperties,
+                            DTOs,
+                            overrideSchemas,
+                        }),
                     );
                 }
 
@@ -201,7 +208,7 @@ export const parseSchema = ({ schema, name, DTOs }: ParseSchemaProps) => {
     }
 };
 
-export const parseSchemas = ({ json, swaggerVersion }: GetSchemasProps) => {
+export const parseSchemas = ({ json, swaggerVersion, overrideSchemas }: GetSchemasProps) => {
     const schemas = getSchemas({ json, swaggerVersion });
     const DTOs = Object.keys(schemas);
 
@@ -214,6 +221,7 @@ export const parseSchemas = ({ json, swaggerVersion }: GetSchemasProps) => {
                     schema: schema,
                     name: dtoName,
                     DTOs: schemas,
+                    overrideSchemas,
                 });
                 resultString += result;
             }
@@ -232,6 +240,7 @@ export const convertToMocks = ({
     folderPath,
     typesPath,
     swaggerVersion = 3,
+    overrideSchemas,
 }: ConvertToMocksProps): string => {
     const schemas = getSchemas({ json, swaggerVersion });
 
@@ -241,7 +250,7 @@ export const convertToMocks = ({
     const disableNoUsedVars = '/* eslint-disable @typescript-eslint/no-unused-vars */\n';
     const importsDescription = `import {${imports}} from '${typesPath}';\n`;
 
-    const result = parseSchemas({ json, swaggerVersion });
+    const result = parseSchemas({ json, swaggerVersion, overrideSchemas });
 
     const resultString = `${disableNoUse}${disableNoUsedVars}${importsDescription}${result}`;
 

--- a/src/mockConverter.ts
+++ b/src/mockConverter.ts
@@ -168,12 +168,13 @@ export const parseSchema = ({ schema, name, DTOs, overrideSchemas }: ParseSchema
                         propertyName,
                         oneOf,
                         DTOs,
+                        overrideSchemas,
                     });
                     mocks.push(arrayOneOf);
                 }
 
                 if ($ref) {
-                    const ref = mockGenerator.getRefTypeMock({ $ref, propertyName, DTOs });
+                    const ref = mockGenerator.getRefTypeMock({ $ref, propertyName, DTOs, overrideSchemas });
                     mocks.push(ref);
                 }
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -7,6 +7,7 @@ export const getSchemaProperties = (objectProps: any) =>
     Object.keys(objectProps).map(property => {
         const {
             type,
+            description,
             $ref,
             oneOf,
             format,
@@ -28,6 +29,7 @@ export const getSchemaProperties = (objectProps: any) =>
 
         return {
             propertyName: property,
+            description,
             type,
             $ref,
             oneOf,

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,7 @@ export interface ConvertToMocksProps {
     folderPath: string;
     typesPath: string;
     swaggerVersion: number;
+    overrideSchemas?: Array<EnumSchema>;
 }
 
 export interface GetSchemasProps {
@@ -154,6 +155,7 @@ export interface GetDictionaryMockProps extends PropertyNameProp {
     xDictionaryKey: any;
     additionalProperties: any;
     DTOs: any;
+    overrideSchemas?: Array<EnumSchema>;
 }
 
 export interface GetRefTypeMockProps extends PropertyNameProp {

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,6 +148,7 @@ export interface GetArrayOfItemsMockProps extends PropertyNameProp {
 export interface GetArrayOfOneOfMockProps extends PropertyNameProp {
     oneOf: any;
     DTOs: any;
+    overrideSchemas?: Array<EnumSchema>;
 }
 
 export interface GetDictionaryMockProps extends PropertyNameProp {
@@ -161,6 +162,7 @@ export interface GetDictionaryMockProps extends PropertyNameProp {
 export interface GetRefTypeMockProps extends PropertyNameProp {
     $ref: string;
     DTOs: any;
+    overrideSchemas?: Array<EnumSchema>;
 }
 
 export interface ParseProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,18 @@ export interface PropertyNameProp {
 
 export interface ResultStringProps extends PropertyNameProp {
     nullable?: boolean;
+    description?: string;
+}
+
+export interface EnumProps {
+    type: string;
+    description: string;
+    enum: Array<string>;
+    'x-enumNames'?: Array<string>;
+}
+
+export interface EnumSchema {
+    [key: string]: EnumProps;
 }
 
 export interface ConvertToTypesProps {
@@ -68,6 +80,7 @@ export interface ConvertToTypesProps {
     fileName: string;
     folderPath: string;
     swaggerVersion: number;
+    overrideSchemas?: Array<EnumSchema>;
 }
 
 export interface ConvertToMocksProps {
@@ -81,10 +94,12 @@ export interface ConvertToMocksProps {
 export interface GetSchemasProps {
     json: { components?: { schemas?: any }; definitions?: any };
     swaggerVersion?: number;
+    overrideSchemas?: Array<EnumSchema>;
 }
 
 export interface ResultStringPropsForNumberType extends ResultStringProps {
     format?: string;
+    description?: string;
     minimum?: number;
     maximum?: number;
     exclusiveMinimum?: boolean;
@@ -93,6 +108,7 @@ export interface ResultStringPropsForNumberType extends ResultStringProps {
 
 export interface ResultStringPropsForArrayType extends ResultStringProps {
     format?: string;
+    description?: string;
     refType: string[];
     minItems?: number;
     maxItems?: number;
@@ -101,6 +117,7 @@ export interface ResultStringPropsForArrayType extends ResultStringProps {
 
 export interface ResultStringPropsForStringType extends ResultStringProps {
     format?: string;
+    description?: string;
     minLength?: number;
     maxLength?: number;
 }
@@ -145,7 +162,7 @@ export interface GetRefTypeMockProps extends PropertyNameProp {
 }
 
 export interface ParseProps {
-    schema: any;
+    schema: EnumProps;
     schemaKey: string;
 }
 

--- a/src/typesConverter.ts
+++ b/src/typesConverter.ts
@@ -262,14 +262,18 @@ const convertToTypesFromSchemaProperties = ({
                         const dictionaryRef = parseRefType(xDictionaryKey[SwaggerProps.$ref].split('/'));
                         const additionalRef = parseRefType(additionalProperties[SwaggerProps.$ref].split('/'));
 
-                        result += `${getDescription(description)}    ${propertyName}: {\n[key in ${dictionaryRef}]: ${additionalRef}; \n }; \n`;
+                        result += `${getDescription(
+                            description,
+                        )}    ${propertyName}: {\n[key in ${dictionaryRef}]: ${additionalRef}; \n }; \n`;
 
                         // Enum keys and Boolean values
                     } else if (xDictionaryKey[SwaggerProps.$ref]) {
                         if (additionalProperties.type && additionalProperties.type === DataTypes.Boolean) {
                             const dictionaryRef = parseRefType(xDictionaryKey[SwaggerProps.$ref].split('/'));
 
-                            result += `${getDescription(description)}    ${propertyName}: {\n[key in ${dictionaryRef}]: boolean; \n }; \n`;
+                            result += `${getDescription(
+                                description,
+                            )}    ${propertyName}: {\n[key in ${dictionaryRef}]: boolean; \n }; \n`;
                         }
                     } else {
                         result += ' "// TODO: Something in wrong" ';
@@ -334,7 +338,15 @@ export const parseSchemas = ({ json, swaggerVersion, overrideSchemas }: GetSchem
                  * Is schema is a simple object or is it extends from another schema
                  */
                 if (schema[SwaggerProps.Type] === DataTypes.Object || schema[SwaggerProps.AllOf]) {
-                    result += parseObject({ schema, schemaKey });
+                    /**
+                     * Sometimes in swagger v2 schema key could be named as SomeDto[AnotherDto]
+                     */
+                    if (swaggerVersion === 2 && schemaKey.includes('[') && schemaKey.includes(']')) {
+                        const strings = schemaKey.split('[');
+                        result += parseObject({ schema, schemaKey: strings[0] });
+                    } else {
+                        result += parseObject({ schema, schemaKey });
+                    }
                 } else if (schema.type === DataTypes.String) {
                     /**
                      * Check if current schema is override

--- a/src/typesConverter.ts
+++ b/src/typesConverter.ts
@@ -20,12 +20,21 @@ const parseRefType = (refType: string[]): string => refType[refType.length - 1];
 const parsePropertyName = ({ propertyName, nullable, type }: any): string =>
     `    ${propertyName}${nullable ? '?' : ''}: ${type};`;
 
-const parseProperty = ({ propertyName, nullable }: { propertyName: string; nullable: boolean }): string => {
-    return `    ${propertyName}${nullable ? '?' : ''}: `;
+const parseProperty = ({
+    propertyName,
+    description,
+    nullable,
+}: {
+    propertyName: string;
+    description?: string;
+    nullable: boolean;
+}): string => {
+    return `${getDescription(description)}    ${propertyName}${nullable ? '?' : ''}: `;
 };
 
 const getResultStringForNumberType = ({
     propertyName,
+    description,
     nullable,
     format,
     minimum,
@@ -50,17 +59,20 @@ const getResultStringForNumberType = ({
 
     const documentation = `${formatString}${minimumString}${maximumString}${exclusiveMinimumString}${exclusiveMaximumString}`;
 
-    return `${nameAndValue}${shouldShowDocs ? ` // ${documentation}` : ''}\n`;
+    return `${getDescription(description)}${nameAndValue}${shouldShowDocs ? ` // ${documentation}` : ''}\n`;
 };
 
-const getResultStringForBooleanType = ({ propertyName, nullable }: ResultStringProps): string => {
+const getResultStringForBooleanType = ({ propertyName, description, nullable }: ResultStringProps): string => {
     const nameAndValue = `    ${propertyName}${nullable ? '?' : ''}: boolean;`;
 
-    return `${nameAndValue}\n`;
+    return `${getDescription(description)}${nameAndValue}\n`;
 };
+
+const getDescription = (description?: string) => `${description ? `/**\n * ${description} \n */\n` : ''}`;
 
 const getResultStringForStringType = ({
     propertyName,
+    description,
     nullable,
     format,
     minLength,
@@ -77,11 +89,12 @@ const getResultStringForStringType = ({
 
     const documentation = `${formatString}${minString}${maxString}`;
 
-    return `${nameAndValue}${shouldShowDocs ? ` // ${documentation}` : ''}\n`;
+    return `${getDescription(description)}${nameAndValue}${shouldShowDocs ? ` // ${documentation}` : ''}\n`;
 };
 
 const getResultStringForArrayType = ({
     propertyName,
+    description,
     nullable,
     refType,
     format,
@@ -102,7 +115,7 @@ const getResultStringForArrayType = ({
     const shouldShowDocs = format || minItems || maxItems || uniqueItems;
     const documentation = `${formatString}${minItemsString}${maxItemsString}${uniqueItemsString}`;
 
-    return `${nameAndValue}${shouldShowDocs ? ` // ${documentation}` : ''}\n`;
+    return `${getDescription(description)}${nameAndValue}${shouldShowDocs ? ` // ${documentation}` : ''}\n`;
 };
 
 const convertToTypesFromSchemaProperties = ({
@@ -114,19 +127,13 @@ const convertToTypesFromSchemaProperties = ({
     schemaKey?: string;
     interfaces?: Array<string>;
 }): string => {
-    let documentation = '';
-
-    if (schema.description) {
-        documentation = `/**\n * ${schema['description']}\n */\n`;
-    }
-
-    const getStandardString = ({ propertyName, nullable, refType, format, isArray }: any) => {
-        return `${parseProperty({ propertyName, nullable })}${parseRefType(refType)}${
+    const getStandardString = ({ propertyName, description, nullable, refType, format, isArray }: any) => {
+        return `${parseProperty({ propertyName, description, nullable })}${parseRefType(refType)}${
             isArray ? '[]' : ''
         };${parseFormat(format)}\n`;
     };
 
-    let result = `${documentation}export interface ${schemaKey}${
+    let result = `${getDescription(schema.description)}export interface ${schemaKey}${
         interfaces ? ` extends ${interfaces.join(', ')} ` : ' '
     }{\n`;
 
@@ -134,6 +141,7 @@ const convertToTypesFromSchemaProperties = ({
         getSchemaProperties(schema.properties).map(
             ({
                 propertyName,
+                description,
                 $ref,
                 items,
                 type,
@@ -155,6 +163,7 @@ const convertToTypesFromSchemaProperties = ({
                 if (type === DataTypes.String) {
                     result += getResultStringForStringType({
                         propertyName,
+                        description,
                         nullable,
                         format,
                         minLength,
@@ -165,6 +174,7 @@ const convertToTypesFromSchemaProperties = ({
                 if (type === DataTypes.Integer || type === DataTypes.Number) {
                     result += getResultStringForNumberType({
                         propertyName,
+                        description,
                         nullable,
                         format,
                         minimum,
@@ -175,7 +185,7 @@ const convertToTypesFromSchemaProperties = ({
                 }
 
                 if (type === DataTypes.Boolean) {
-                    result += getResultStringForBooleanType({ propertyName, nullable });
+                    result += getResultStringForBooleanType({ propertyName, description, nullable });
                 }
 
                 if (type === DataTypes.Array && items) {
@@ -184,6 +194,7 @@ const convertToTypesFromSchemaProperties = ({
 
                         result += getResultStringForArrayType({
                             propertyName,
+                            description,
                             nullable,
                             refType,
                             format,
@@ -209,6 +220,7 @@ const convertToTypesFromSchemaProperties = ({
 
                         result += `${parseProperty({
                             propertyName,
+                            description,
                             nullable,
                         })}${type}${shouldShowBrackets};${parseFormat(format)}${
                             maxItems ? ` // maxItems: ${maxItems}` : ''
@@ -218,7 +230,14 @@ const convertToTypesFromSchemaProperties = ({
 
                 if (oneOf && Array.isArray(oneOf) && oneOf[0][SwaggerProps.$ref]) {
                     const refType = oneOf[0][SwaggerProps.$ref].split('/');
-                    result += getStandardString({ propertyName, nullable, refType, format, isArray: false });
+                    result += getStandardString({
+                        propertyName,
+                        description,
+                        nullable,
+                        refType,
+                        format,
+                        isArray: false,
+                    });
                 }
 
                 if ($ref) {
@@ -243,14 +262,14 @@ const convertToTypesFromSchemaProperties = ({
                         const dictionaryRef = parseRefType(xDictionaryKey[SwaggerProps.$ref].split('/'));
                         const additionalRef = parseRefType(additionalProperties[SwaggerProps.$ref].split('/'));
 
-                        result += `    ${propertyName}: {\n[key in ${dictionaryRef}]: ${additionalRef}; \n }; \n`;
+                        result += `${getDescription(description)}    ${propertyName}: {\n[key in ${dictionaryRef}]: ${additionalRef}; \n }; \n`;
 
                         // Enum keys and Boolean values
                     } else if (xDictionaryKey[SwaggerProps.$ref]) {
                         if (additionalProperties.type && additionalProperties.type === DataTypes.Boolean) {
                             const dictionaryRef = parseRefType(xDictionaryKey[SwaggerProps.$ref].split('/'));
 
-                            result += `    ${propertyName}: {\n[key in ${dictionaryRef}]: boolean; \n }; \n`;
+                            result += `${getDescription(description)}    ${propertyName}: {\n[key in ${dictionaryRef}]: boolean; \n }; \n`;
                         }
                     } else {
                         result += ' "// TODO: Something in wrong" ';
@@ -265,7 +284,7 @@ const convertToTypesFromSchemaProperties = ({
     return result;
 };
 
-export const parseObject = ({ schema, schemaKey }: { schema: any; schemaKey: any }) => {
+export const parseObject = ({ schema, schemaKey }: { schema: any; schemaKey: string }) => {
     if (schema[SwaggerProps.AllOf] && Array.isArray(schema[SwaggerProps.AllOf])) {
         const interfacesNames = schema[SwaggerProps.AllOf]
             .filter((e: { $ref?: string }) => e[SwaggerProps.$ref])
@@ -287,7 +306,9 @@ export const parseObject = ({ schema, schemaKey }: { schema: any; schemaKey: any
  * to "export type ${name} = 'one' | 'two' | 'three';"
  */
 export const parseEnum = ({ schema, schemaKey }: ParseProps): string => {
-    let result = `export type ${schemaKey} = `;
+    const description = schema.description;
+
+    let result = `${description ? `/**\n * ${description} \n */\n` : ''}export type ${schemaKey} = `;
 
     const enums = schema.enum;
     const len = enums.length;
@@ -299,7 +320,7 @@ export const parseEnum = ({ schema, schemaKey }: ParseProps): string => {
     return result;
 };
 
-export const parseSchemas = ({ json, swaggerVersion }: GetSchemasProps) => {
+export const parseSchemas = ({ json, swaggerVersion, overrideSchemas }: GetSchemasProps) => {
     const schemas = getSchemas({ json, swaggerVersion });
 
     if (schemas) {
@@ -315,7 +336,18 @@ export const parseSchemas = ({ json, swaggerVersion }: GetSchemasProps) => {
                 if (schema[SwaggerProps.Type] === DataTypes.Object || schema[SwaggerProps.AllOf]) {
                     result += parseObject({ schema, schemaKey });
                 } else if (schema.type === DataTypes.String) {
-                    result += parseEnum({ schema, schemaKey });
+                    /**
+                     * Check if current schema is override
+                     */
+                    if (overrideSchemas?.length && overrideSchemas.find(e => e[schemaKey])) {
+                        // for TS happiness
+                        const overrideSchema = overrideSchemas.find(e => e[schemaKey]);
+                        if (overrideSchema) {
+                            result += parseEnum({ schema: overrideSchema[schemaKey], schemaKey });
+                        }
+                    } else {
+                        result += parseEnum({ schema, schemaKey });
+                    }
                 } else {
                     result += `// TODO: ERROR! Something wrong with ${schemaKey} \n`;
                 }
@@ -331,8 +363,14 @@ export const parseSchemas = ({ json, swaggerVersion }: GetSchemasProps) => {
     }
 };
 
-export const convertToTypes = ({ json, fileName, folderPath, swaggerVersion }: ConvertToTypesProps) => {
-    const resultString = parseSchemas({ json, swaggerVersion });
+export const convertToTypes = ({
+    json,
+    fileName,
+    folderPath,
+    swaggerVersion,
+    overrideSchemas,
+}: ConvertToTypesProps) => {
+    const resultString = parseSchemas({ json, swaggerVersion, overrideSchemas });
     writeToFile({
         folderPath,
         fileName,

--- a/tests/mockConverter.test.ts
+++ b/tests/mockConverter.test.ts
@@ -1305,7 +1305,6 @@ it('should generate mocks for a "dictionary" type boolean', async () => {
                     enum: ['Read', 'Write'],
                 },
             },
-
         },
     };
 
@@ -1345,6 +1344,91 @@ export const aCollectionDtoAPI = (overrides?: Partial<CollectionDto>): Collectio
         folderPath: './someFolder',
         typesPath: './pathToTypes',
         swaggerVersion: 3,
+    });
+
+    expect(result).toEqual(expected);
+});
+
+it('should generate overrided mocks for enum type', async () => {
+    const json = {
+        paths: {},
+        servers: {},
+        info: {},
+        components: {
+            schemas: {
+                UserMetadata: {
+                    type: 'object',
+                    additionalProperties: false,
+                    properties: {
+                        serviceOffers: {
+                            type: 'object',
+                            nullable: true,
+                            'x-dictionaryKey': {
+                                $ref: '#/components/schemas/ServiceOfferKind',
+                            },
+                            additionalProperties: {
+                                $ref: '#/components/schemas/BillingProviderKind',
+                            },
+                        },
+                    },
+                },
+                ServiceOfferKind: {
+                    type: 'string',
+                    description: '',
+                    'x-enumNames': [
+                        'MasteringAndDistribution',
+                        'Video',
+                        'Samples',
+                        'Mastering',
+                        'Distribution',
+                        'Sessions',
+                    ],
+                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+                },
+                BillingProviderKind: {
+                    type: 'string',
+                    description: '',
+                    'x-enumNames': ['Legacy', 'Fusebill'],
+                    enum: ['Legacy', 'Fusebill'],
+                },
+            },
+        },
+    };
+
+    const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {UserMetadata, ServiceOfferKind, BillingProviderKind} from './pathToTypes';
+
+export const anUserMetadataAPI = (overrides?: Partial<UserMetadata>): UserMetadata => {
+  return {
+    serviceOffers: { 
+"masteringAndDistribution": "Legacy",
+"video": "Legacy",
+"samples": "Legacy",
+"mastering": "Legacy",
+"distribution": "Legacy",
+"sessions": "Legacy",
+},
+  ...overrides,
+  };
+};
+ 
+`;
+    const result = await convertToMocks({
+        json,
+        fileName: "doesn't matter",
+        folderPath: './someFolder',
+        typesPath: './pathToTypes',
+        swaggerVersion: 3,
+        overrideSchemas: [
+            {
+                ServiceOfferKind: {
+                    type: 'string',
+                    description: 'Warning! This type is overrided',
+                    enum: ['masteringAndDistribution', 'video', 'samples', 'mastering', 'distribution', 'sessions'],
+                },
+            },
+        ],
     });
 
     expect(result).toEqual(expected);

--- a/tests/mockConverter.test.ts
+++ b/tests/mockConverter.test.ts
@@ -1568,3 +1568,49 @@ export const aNextSubscriptionAPI = (overrides?: Partial<NextSubscription>): Nex
 
     expect(result).toEqual(expected);
 });
+
+it('should generate mocks for a URI type', async () => {
+    const json = {
+        paths: {},
+        servers: {},
+        info: {},
+        components: {
+            schemas: {
+                DownloadDto: {
+                    type: "object",
+                    additionalProperties: false,
+                    properties: {
+                        url: {
+                            type: "string",
+                            format: "uri",
+                            nullable: true
+                        }
+                    }
+                },
+            },
+
+        },
+    };
+
+    const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {DownloadDto} from './pathToTypes';
+
+export const aDownloadDtoAPI = (overrides?: Partial<DownloadDto>): DownloadDto => {
+  return {
+    url: 'http://www.Wisozk.us/',
+  ...overrides,
+  };
+};
+ 
+`;
+    const result = await convertToMocks({
+        json,
+        fileName: "doesn't matter",
+        folderPath: './someFolder',
+        typesPath: './pathToTypes',
+        swaggerVersion: 3,
+    });
+
+    expect(result).toEqual(expected);
+});

--- a/tests/mockConverter.test.ts
+++ b/tests/mockConverter.test.ts
@@ -1349,7 +1349,7 @@ export const aCollectionDtoAPI = (overrides?: Partial<CollectionDto>): Collectio
     expect(result).toEqual(expected);
 });
 
-it('should generate overrided mocks for enum type', async () => {
+it('should generate overrided mocks for dictionary enum type', async () => {
     const json = {
         paths: {},
         servers: {},
@@ -1409,6 +1409,141 @@ export const anUserMetadataAPI = (overrides?: Partial<UserMetadata>): UserMetada
 "distribution": "Legacy",
 "sessions": "Legacy",
 },
+  ...overrides,
+  };
+};
+ 
+`;
+    const result = await convertToMocks({
+        json,
+        fileName: "doesn't matter",
+        folderPath: './someFolder',
+        typesPath: './pathToTypes',
+        swaggerVersion: 3,
+        overrideSchemas: [
+            {
+                ServiceOfferKind: {
+                    type: 'string',
+                    description: 'Warning! This type is overrided',
+                    enum: ['masteringAndDistribution', 'video', 'samples', 'mastering', 'distribution', 'sessions'],
+                },
+            },
+        ],
+    });
+
+    expect(result).toEqual(expected);
+});
+
+it('should generate overrided mocks for oneOf enum type', async () => {
+    const json = {
+        paths: {},
+        servers: {},
+        info: {},
+        components: {
+            schemas: {
+                CurrentSubscription: {
+                    type: "object",
+                    additionalProperties: false,
+                    properties: {
+                        serviceOffer: {
+                            description: "the service offer of the subscription.",
+                            oneOf: [
+                                {
+                                    $ref: "#/components/schemas/ServiceOfferKind"
+                                }
+                            ]
+                        },
+                    }
+                },
+                ServiceOfferKind: {
+                    type: 'string',
+                    description: '',
+                    'x-enumNames': [
+                        'MasteringAndDistribution',
+                        'Video',
+                        'Samples',
+                        'Mastering',
+                        'Distribution',
+                        'Sessions',
+                    ],
+                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+                },
+            },
+        },
+    };
+
+    const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {CurrentSubscription, ServiceOfferKind} from './pathToTypes';
+
+export const aCurrentSubscriptionAPI = (overrides?: Partial<CurrentSubscription>): CurrentSubscription => {
+  return {
+    serviceOffer: 'masteringAndDistribution',
+  ...overrides,
+  };
+};
+ 
+`;
+    const result = await convertToMocks({
+        json,
+        fileName: "doesn't matter",
+        folderPath: './someFolder',
+        typesPath: './pathToTypes',
+        swaggerVersion: 3,
+        overrideSchemas: [
+            {
+                ServiceOfferKind: {
+                    type: 'string',
+                    description: 'Warning! This type is overrided',
+                    enum: ['masteringAndDistribution', 'video', 'samples', 'mastering', 'distribution', 'sessions'],
+                },
+            },
+        ],
+    });
+
+    expect(result).toEqual(expected);
+});
+
+it('should generate overrided mocks for $ref enum type', async () => {
+    const json = {
+        paths: {},
+        servers: {},
+        info: {},
+        components: {
+            schemas: {
+                NextSubscription: {
+                    type: "object",
+                    additionalProperties: false,
+                    properties: {
+                        serviceOffer: {
+                            $ref: "#/components/schemas/ServiceOfferKind"
+                        },
+                    }
+                },
+                ServiceOfferKind: {
+                    type: 'string',
+                    description: '',
+                    'x-enumNames': [
+                        'MasteringAndDistribution',
+                        'Video',
+                        'Samples',
+                        'Mastering',
+                        'Distribution',
+                        'Sessions',
+                    ],
+                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+                },
+            },
+        },
+    };
+
+    const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {NextSubscription, ServiceOfferKind} from './pathToTypes';
+
+export const aNextSubscriptionAPI = (overrides?: Partial<NextSubscription>): NextSubscription => {
+  return {
+    serviceOffer: 'masteringAndDistribution',
   ...overrides,
   };
 };

--- a/tests/typeConverter.test.ts
+++ b/tests/typeConverter.test.ts
@@ -934,7 +934,6 @@ export type UserOperation = 'Read' | 'Write';
 });
 
 it('should return overrided enum schema', async () => {
-
     // What will be fetched from Swagger Json
     const example = {
         components: {
@@ -1081,6 +1080,41 @@ export interface PlanFrequencyIdentifier {
  * Boolean description 
  */
     isDefault: boolean;
+}
+ 
+`;
+    expect(resultString).toEqual(expectedString);
+});
+
+it('should return CollectionResponseDto', async () => {
+    const example = {
+        definitions: {
+            'CollectionResponseDto[StoredCreditCardDto]': {
+                title: 'CollectionResponse`1',
+                type: 'object',
+                properties: {
+                    data: {
+                        type: 'array',
+                        items: {
+                            $ref: '#/definitions/StoredCreditCardDto',
+                        },
+                    },
+                    paging: {
+                        $ref: '#/definitions/PagingDto',
+                    },
+                },
+            },
+        },
+    };
+
+    const resultString = parseSchemas({
+        json: example,
+        swaggerVersion: 2,
+    });
+
+    const expectedString = `export interface CollectionResponseDto {
+    data: StoredCreditCardDto[];
+    paging: PagingDto;
 }
  
 `;

--- a/tests/typeConverter.test.ts
+++ b/tests/typeConverter.test.ts
@@ -107,7 +107,7 @@ describe('TS types generation', () => {
         const result = parseObject({ schema: swaggerJson, schemaKey: 'AssetDto' });
 
         const expectedString = `/**
- * DESCRIPTION
+ * DESCRIPTION 
  */
 export interface AssetDto {
     id: string; // format: "guid"
@@ -928,6 +928,160 @@ export interface CollectionDto {
  }; 
 }
 export type UserOperation = 'Read' | 'Write';
+ 
+`;
+    expect(resultString).toEqual(expectedString);
+});
+
+it('should return overrided enum schema', async () => {
+
+    // What will be fetched from Swagger Json
+    const example = {
+        components: {
+            schemas: {
+                ServiceOfferKind: {
+                    type: 'string',
+                    description: '',
+                    'x-enumNames': [
+                        'MasteringAndDistribution',
+                        'Video',
+                        'Samples',
+                        'Mastering',
+                        'Distribution',
+                        'Sessions',
+                    ],
+                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+                },
+            },
+        },
+    };
+
+    const resultString = parseSchemas({
+        json: example,
+        swaggerVersion: 3,
+        // Overrided value "ServiceOfferKind" enum
+        overrideSchemas: [
+            {
+                ServiceOfferKind: {
+                    type: 'string',
+                    description: 'Warning! This type is overrided',
+                    enum: ['masteringAndDistribution', 'video', 'samples', 'mastering', 'distribution', 'sessions'],
+                },
+            },
+        ],
+    });
+
+    const expectedString = `/**
+ * Warning! This type is overrided 
+ */
+export type ServiceOfferKind = 'masteringAndDistribution' | 'video' | 'samples' | 'mastering' | 'distribution' | 'sessions';
+ 
+`;
+    expect(resultString).toEqual(expectedString);
+});
+
+it('should return description', async () => {
+    const example = {
+        components: {
+            schemas: {
+                PlanFrequencyIdentifier: {
+                    type: 'object',
+                    description: 'PlanFrequencyIdentifier description',
+                    additionalProperties: false,
+                    properties: {
+                        code: {
+                            type: 'string',
+                            description: 'The Fusebill plan code.',
+                            nullable: true,
+                        },
+                        currentQuantity: {
+                            type: 'number',
+                            description: 'The current quantity of the product within the subscription.',
+                            format: 'decimal',
+                        },
+                        numberOfCredits: {
+                            type: 'integer',
+                            description: 'The number of credits associated to this subscription product.',
+                            format: 'int32',
+                            nullable: true,
+                        },
+                        frequency: {
+                            description: 'The interval of the plan (monthly/yearly).',
+                            oneOf: [
+                                {
+                                    $ref: '#/components/schemas/Interval',
+                                },
+                            ],
+                        },
+                        hasOverduePayment: {
+                            type: 'object',
+                            description: 'Says if the user has overdue payments by service offer.',
+                            nullable: true,
+                            'x-dictionaryKey': {
+                                $ref: '#/components/schemas/ServiceOfferKind',
+                            },
+                            additionalProperties: {
+                                type: 'boolean',
+                            },
+                        },
+                        userIds: {
+                            type: 'array',
+                            description: 'The user IDs.',
+                            items: {
+                                type: 'string',
+                                format: 'guid',
+                            },
+                        },
+                        isDefault: {
+                            type: 'boolean',
+                            description: 'Boolean description',
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    const resultString = parseSchemas({
+        json: example,
+        swaggerVersion: 3,
+    });
+
+    const expectedString = `/**
+ * PlanFrequencyIdentifier description 
+ */
+export interface PlanFrequencyIdentifier {
+/**
+ * The Fusebill plan code. 
+ */
+    code?: string;
+/**
+ * The current quantity of the product within the subscription. 
+ */
+    currentQuantity: number; // format: "decimal"
+/**
+ * The number of credits associated to this subscription product. 
+ */
+    numberOfCredits?: number; // format: "int32"
+/**
+ * The interval of the plan (monthly/yearly). 
+ */
+    frequency: Interval;
+/**
+ * Says if the user has overdue payments by service offer. 
+ */
+    hasOverduePayment: {
+[key in ServiceOfferKind]: boolean; 
+ }; 
+/**
+ * The user IDs. 
+ */
+    userIds: string[];
+/**
+ * Boolean description 
+ */
+    isDefault: boolean;
+}
  
 `;
     expect(resultString).toEqual(expectedString);


### PR DESCRIPTION
## 📄  Description
Added ability to override enum types (for now - only enums).
**_Why do we need that?_** 
Explained  in this story https://mixgenius.atlassian.net/browse/CHFE-726.
And as a reference: 
![2020-12-01_15-34-33](https://user-images.githubusercontent.com/22501553/100747680-0b9b7280-33eb-11eb-8f17-e1b2a8583c8f.jpg)

Added doc generation from open-api description properties:
![2020-12-01_15-37-46](https://user-images.githubusercontent.com/22501553/100747835-3c7ba780-33eb-11eb-9d1e-f6cde2676d98.jpg)

## 📦  Changes

## ⛰️  Screenshots/Videos

## ✅  Checklist
- [x] Contains no duplicate/temporary code
- [x] Contains no sensitive information
- [ ] Error handling added
- [x] Unit tests added

## Part 2: https://github.com/LandrAudio/openapi-codegen-typescript/pull/19
## Part 3: https://github.com/LandrAudio/openapi-codegen-typescript/pull/20

## 🔗  JIRA Issue
https://mixgenius.atlassian.net/browse/CHFE-777
https://mixgenius.atlassian.net/browse/CHFE-778
