### PR TITLE
fix(type): fix Fix "CollectionResponseDto" type (part 2)

### DIFF
--- a/src/typesConverter.ts
+++ b/src/typesConverter.ts
@@ -262,14 +262,18 @@ const convertToTypesFromSchemaProperties = ({
                         const dictionaryRef = parseRefType(xDictionaryKey[SwaggerProps.$ref].split('/'));
                         const additionalRef = parseRefType(additionalProperties[SwaggerProps.$ref].split('/'));
 
-                        result += `${getDescription(description)}    ${propertyName}: {\n[key in ${dictionaryRef}]: ${additionalRef}; \n }; \n`;
+                        result += `${getDescription(
+                            description,
+                        )}    ${propertyName}: {\n[key in ${dictionaryRef}]: ${additionalRef}; \n }; \n`;
 
                         // Enum keys and Boolean values
                     } else if (xDictionaryKey[SwaggerProps.$ref]) {
                         if (additionalProperties.type && additionalProperties.type === DataTypes.Boolean) {
                             const dictionaryRef = parseRefType(xDictionaryKey[SwaggerProps.$ref].split('/'));
 
-                            result += `${getDescription(description)}    ${propertyName}: {\n[key in ${dictionaryRef}]: boolean; \n }; \n`;
+                            result += `${getDescription(
+                                description,
+                            )}    ${propertyName}: {\n[key in ${dictionaryRef}]: boolean; \n }; \n`;
                         }
                     } else {
                         result += ' "// TODO: Something in wrong" ';
@@ -334,7 +338,15 @@ export const parseSchemas = ({ json, swaggerVersion, overrideSchemas }: GetSchem
                  * Is schema is a simple object or is it extends from another schema
                  */
                 if (schema[SwaggerProps.Type] === DataTypes.Object || schema[SwaggerProps.AllOf]) {
-                    result += parseObject({ schema, schemaKey });
+                    /**
+                     * Sometimes in swagger v2 schema key could be named as SomeDto[AnotherDto]
+                     */
+                    if (swaggerVersion === 2 && schemaKey.includes('[') && schemaKey.includes(']')) {
+                        const strings = schemaKey.split('[');
+                        result += parseObject({ schema, schemaKey: strings[0] });
+                    } else {
+                        result += parseObject({ schema, schemaKey });
+                    }
                 } else if (schema.type === DataTypes.String) {
                     /**
                      * Check if current schema is override

--- a/tests/typeConverter.test.ts
+++ b/tests/typeConverter.test.ts
@@ -934,7 +934,6 @@ export type UserOperation = 'Read' | 'Write';
 });
 
 it('should return overrided enum schema', async () => {
-
     // What will be fetched from Swagger Json
     const example = {
         components: {
@@ -1081,6 +1080,41 @@ export interface PlanFrequencyIdentifier {
  * Boolean description 
  */
     isDefault: boolean;
+}
+ 
+`;
+    expect(resultString).toEqual(expectedString);
+});
+
+it('should return CollectionResponseDto', async () => {
+    const example = {
+        definitions: {
+            'CollectionResponseDto[StoredCreditCardDto]': {
+                title: 'CollectionResponse`1',
+                type: 'object',
+                properties: {
+                    data: {
+                        type: 'array',
+                        items: {
+                            $ref: '#/definitions/StoredCreditCardDto',
+                        },
+                    },
+                    paging: {
+                        $ref: '#/definitions/PagingDto',
+                    },
+                },
+            },
+        },
+    };
+
+    const resultString = parseSchemas({
+        json: example,
+        swaggerVersion: 2,
+    });
+
+    const expectedString = `export interface CollectionResponseDto {
+    data: StoredCreditCardDto[];
+    paging: PagingDto;
 }
  
 `;


### PR DESCRIPTION
## 📄  Description
Fixed generation of swagger v2 **CollectionResponseDto** type:
```javascript
const example = {
        definitions: {
            'CollectionResponseDto[StoredCreditCardDto]': {
                title: 'CollectionResponse`1',
                type: 'object',
                properties: {
                    data: {
                        type: 'array',
                        items: {
                            $ref: '#/definitions/StoredCreditCardDto',
                        },
                    },
                    paging: {
                        $ref: '#/definitions/PagingDto',
                    },
                },
            },
        },
    };
```

## 📦  Changes

## ⛰️  Screenshots/Videos

## ✅  Checklist
- [x] Contains no duplicate/temporary code
- [x] Contains no sensitive information
- [ ] Error handling added
- [x] Unit tests added

## 🔗  JIRA Issue
https://mixgenius.atlassian.net/browse/CHFE-774
