### PR TITLE
fix(type): fix mock codegen for "uri" Swagger format (part 3)

### DIFF
--- a/src/MockGenerateHelper.ts
+++ b/src/MockGenerateHelper.ts
@@ -17,9 +17,9 @@ import {
 } from './types';
 
 export class MockGenerateHelper {
-    private casual: any;
+    private casual: Casual.Generators & Casual.Casual;
 
-    constructor(casual: any) {
+    constructor(casual: Casual.Generators & Casual.Casual) {
         this.casual = casual;
     }
 
@@ -38,6 +38,8 @@ export class MockGenerateHelper {
             value = `'2019-06-10'`;
         } else if (format === StringFormats.Email) {
             value = `'${this.casual.email}'`;
+        } else if (format === StringFormats.Uri) {
+            value = `'${this.casual.url}'`;
         }
 
         if (!value) {

--- a/tests/mockConverter.test.ts
+++ b/tests/mockConverter.test.ts
@@ -1349,3 +1349,49 @@ export const aCollectionDtoAPI = (overrides?: Partial<CollectionDto>): Collectio
 
     expect(result).toEqual(expected);
 });
+
+it('should generate mocks for a URI type', async () => {
+    const json = {
+        paths: {},
+        servers: {},
+        info: {},
+        components: {
+            schemas: {
+                DownloadDto: {
+                    type: "object",
+                    additionalProperties: false,
+                    properties: {
+                        url: {
+                            type: "string",
+                            format: "uri",
+                            nullable: true
+                        }
+                    }
+                },
+            },
+
+        },
+    };
+
+    const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {DownloadDto} from './pathToTypes';
+
+export const aDownloadDtoAPI = (overrides?: Partial<DownloadDto>): DownloadDto => {
+  return {
+    url: 'http://www.Wisozk.us/',
+  ...overrides,
+  };
+};
+ 
+`;
+    const result = await convertToMocks({
+        json,
+        fileName: "doesn't matter",
+        folderPath: './someFolder',
+        typesPath: './pathToTypes',
+        swaggerVersion: 3,
+    });
+
+    expect(result).toEqual(expected);
+});


### PR DESCRIPTION
## 📄  Description
Fixed mock codegen of `uri` format

## 📦  Changes

## ⛰️  Screenshots/Videos

## Part 1: https://github.com/LandrAudio/openapi-codegen-typescript/pull/18
## Part 2: https://github.com/LandrAudio/openapi-codegen-typescript/pull/19

## ✅  Checklist
- [x] Contains no duplicate/temporary code
- [x] Contains no sensitive information
- [ ] Error handling added
- [x] Unit tests added

## 🔗  JIRA Issue
https://mixgenius.atlassian.net/browse/CHFE-784
