### PR TITLE
fix(type): fix mocks codegen for the v2 Type[AnotherType] annotations and remove "swaggerVersion" prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,12 @@ const { fetchSwaggerJsonFile, convertToTypes } = require('openapi-codegen-typesc
 
 async function doSomething() {
   const json = await fetchSwaggerJsonFile('https://custom/swagger.json');
-  convertToTypes({ json, fileName: 'dtoAPI', folderPath: 'src/types/generated', swaggerVersion: 3 });
+  convertToTypes({ json, fileName: 'dtoAPI', folderPath: 'src/types/generated' });
 }
 ```
 
 This function ('doSomething()') fetches json file from urls, then converts json
 to typescript "types" and writes "types" to file ('src/types/generated/dtoAPI')
-If "swaggerVersion" will not be provided - it will be set to "3" by default.
 
 - For generating mock files that are using converted types
 
@@ -52,15 +51,13 @@ async function doSomething() {
     json,
     fileName: 'dtoAPI',
     folderPath: 'src/mocks/generated',
-    typesPath: '../../types/generated/dtoAPI',
-    swaggerVersion: 3,
+    typesPath: '../../types/generated/dtoAPI'
   });
 }
 ```
 
 This function ('doSomething()') fetches json file from urls, then converts json to "mocks" and writes "mocks" to file
 ('src/mocks/generated/dtoAPI') with imports from typescript types ('src/types/generated/dtoAPI')
-If "swaggerVersion" will not be provided - it will be set to "3" by default.
 
 ## Overriding enum schema type
 
@@ -102,15 +99,13 @@ async function main() {
     json,
     fileName: 'typesAPI',
     folderPath: 'src/types/generated',
-    swaggerVersion: 3,
-    overrideSchemas,
+    overrideSchemas
   });
   convertToMocks({
     json,
     fileName: 'mocksAPI',
     folderPath: 'src/mocks/generated',
-    typesPath: '../../types/generated/typesAPI',
-    swaggerVersion: 3,
+    typesPath: '../../types/generated/typesAPI'
   });
 }
 
@@ -126,13 +121,12 @@ const petShopLink = 'https://petstore.swagger.io/v2/swagger.json';
 
 async function main() {
   const json = await fetchSwaggerJsonFile(petShopLink);
-  convertToTypes({ json, fileName: 'typesAPI', folderPath: 'src/types/generated', swaggerVersion: 3 });
+  convertToTypes({ json, fileName: 'typesAPI', folderPath: 'src/types/generated' });
   convertToMocks({
     json,
     fileName: 'mocksAPI',
     folderPath: 'src/mocks/generated',
-    typesPath: '../../types/generated/typesAPI',
-    swaggerVersion: 3,
+    typesPath: '../../types/generated/typesAPI'
   });
 }
 
@@ -147,22 +141,20 @@ main();
 
 Returns a swagger json object;
 
-#### convertToTypes({ json, fileName, folderPath, swaggerVersion })
+#### convertToTypes({ json, fileName, folderPath })
 
 `json`: `object` - swagger json data;
 `fileName`: `string` - name of the file, where typescript types data will be saved;
 `folderPath`: `string` - folder path the `fileName`, where typescript types data will be saved;
-`swaggerVersion`: `number` - version of the swagger json file (specification). `3` by default;
 
 Returns `void`;
 
-#### convertToMocks({ json, fileName, folderPath, typesPath, swaggerVersion })
+#### convertToMocks({ json, fileName, folderPath, typesPath })
 
 `json`: `object` - swagger json data;
 `fileName`: `string` - name of the file, where mocks data will be saved;
 `folderPath`: `string` - folder path the `fileName`, where mocks data will be saved;
 `typesPath`: `string` - folder path to `types`, where typescript types data are saved.
 Path to `types` will be inserted to the type imports in generated mocks (generated -> import {...} from `typesPath`;);
-`swaggerVersion`: `number` - version of the swagger json file (specification);
 
 Returns `void`;

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,4 +1,4 @@
-import { GetSchemasProps } from './types';
+import { GetSchemasProps, SwaggerV2, SwaggerV3 } from './types';
 
 const fs = require('fs');
 const fetch = require('node-fetch');
@@ -72,14 +72,21 @@ export const hashedString = (string: string) => {
     return hash;
 };
 
-export const getSchemas = ({ json, swaggerVersion = 3 }: GetSchemasProps) => {
-    switch (swaggerVersion) {
-        case 3:
-            return json?.components?.schemas;
-        case 2:
-            return json?.definitions;
-        default:
-            return json?.components?.schemas;
+export function isSwaggerV3(json: SwaggerV2 | SwaggerV3): json is SwaggerV3 {
+    return Boolean((json as SwaggerV3).components) && (json as SwaggerV3).openapi === '3.0.0';
+}
+
+export function isSwaggerV2(json: SwaggerV2 | SwaggerV3): json is SwaggerV2 {
+    return (json as SwaggerV2).swagger === '2.0' && Boolean((json as SwaggerV2).definitions);
+}
+
+export const getSchemas = ({ json }: GetSchemasProps): any => {
+    if (isSwaggerV3(json)) {
+        return json?.components?.schemas;
+    } else if (isSwaggerV2(json)) {
+        return json?.definitions;
+    } else {
+        throw Error('Schema parse exception. Unsupported version');
     }
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,22 +79,29 @@ export interface ConvertToTypesProps {
     json: any;
     fileName: string;
     folderPath: string;
-    swaggerVersion: number;
     overrideSchemas?: Array<EnumSchema>;
 }
 
 export interface ConvertToMocksProps {
-    json: any;
+    json: SwaggerV2 | SwaggerV3;
     fileName: string;
     folderPath: string;
     typesPath: string;
-    swaggerVersion: number;
     overrideSchemas?: Array<EnumSchema>;
 }
 
+export interface SwaggerV2 {
+    swagger: '2.0'; // "2.0"
+    definitions?: any;
+}
+
+export interface SwaggerV3 {
+    openapi: '3.0.0'; // "3.0.0",
+    components?: { schemas?: any };
+}
+
 export interface GetSchemasProps {
-    json: { components?: { schemas?: any }; definitions?: any };
-    swaggerVersion?: number;
+    json: SwaggerV2 | SwaggerV3;
     overrideSchemas?: Array<EnumSchema>;
 }
 

--- a/src/typesConverter.ts
+++ b/src/typesConverter.ts
@@ -13,7 +13,7 @@ import {
     ConvertToTypesProps,
     GetSchemasProps,
 } from './types';
-import { getSchemaProperties, getSchemas, writeToFile } from './shared';
+import { getSchemaProperties, getSchemas, isSwaggerV2, writeToFile } from './shared';
 
 const parseFormat = (format?: string): string => (format ? `format: "${format}"` : '');
 const parseRefType = (refType: string[]): string => refType[refType.length - 1];
@@ -324,8 +324,8 @@ export const parseEnum = ({ schema, schemaKey }: ParseProps): string => {
     return result;
 };
 
-export const parseSchemas = ({ json, swaggerVersion, overrideSchemas }: GetSchemasProps) => {
-    const schemas = getSchemas({ json, swaggerVersion });
+export const parseSchemas = ({ json, overrideSchemas }: GetSchemasProps) => {
+    const schemas = getSchemas({ json });
 
     if (schemas) {
         const schemasKeys = Object.keys(schemas);
@@ -341,7 +341,7 @@ export const parseSchemas = ({ json, swaggerVersion, overrideSchemas }: GetSchem
                     /**
                      * Sometimes in swagger v2 schema key could be named as SomeDto[AnotherDto]
                      */
-                    if (swaggerVersion === 2 && schemaKey.includes('[') && schemaKey.includes(']')) {
+                    if (isSwaggerV2(json) && schemaKey.includes('[') && schemaKey.includes(']')) {
                         const strings = schemaKey.split('[');
                         result += parseObject({ schema, schemaKey: strings[0] });
                     } else {
@@ -375,14 +375,8 @@ export const parseSchemas = ({ json, swaggerVersion, overrideSchemas }: GetSchem
     }
 };
 
-export const convertToTypes = ({
-    json,
-    fileName,
-    folderPath,
-    swaggerVersion,
-    overrideSchemas,
-}: ConvertToTypesProps) => {
-    const resultString = parseSchemas({ json, swaggerVersion, overrideSchemas });
+export const convertToTypes = ({ json, fileName, folderPath, overrideSchemas }: ConvertToTypesProps) => {
+    const resultString = parseSchemas({ json, overrideSchemas });
     writeToFile({
         folderPath,
         fileName,

--- a/src/utils/test-utils.ts
+++ b/src/utils/test-utils.ts
@@ -1,0 +1,17 @@
+import { SwaggerV2, SwaggerV3 } from '../types';
+
+export const swaggerV3Mock = (schemas: any): SwaggerV3 => {
+    return {
+        openapi: '3.0.0',
+        components: {
+            schemas,
+        },
+    };
+};
+
+export const swaggerV2Mock = (definitions: any): SwaggerV2 => {
+    return {
+        swagger: '2.0',
+        definitions,
+    };
+};

--- a/tests/mockConverter.test.ts
+++ b/tests/mockConverter.test.ts
@@ -5,6 +5,7 @@ import {
     parseSchema,
     parseSchemas,
 } from '../src/mockConverter';
+import { swaggerV2Mock, swaggerV3Mock } from '../src/utils/test-utils';
 
 jest.mock('fs');
 
@@ -587,33 +588,26 @@ it('should properly parse schemas', async () => {
     fs.existsSync.mockReturnValue(false);
     fs.mkdirSync.mockReturnValue(false);
 
-    const json = {
-        paths: {},
-        servers: {},
-        info: {},
-        components: {
-            schemas: {
-                One: {
-                    type: 'object',
-                    properties: {
-                        name: {
-                            type: 'string',
-                        },
-                    },
-                },
-                Two: {
-                    type: 'object',
-                    properties: {
-                        name: {
-                            type: 'number',
-                        },
-                    },
+    const json = swaggerV3Mock({
+        One: {
+            type: 'object',
+            properties: {
+                name: {
+                    type: 'string',
                 },
             },
         },
-    };
+        Two: {
+            type: 'object',
+            properties: {
+                name: {
+                    type: 'number',
+                },
+            },
+        },
+    });
 
-    const result = parseSchemas({ json, swaggerVersion: 3 });
+    const result = parseSchemas({ json });
 
     const expectedString = `
 export const aOneAPI = (overrides?: Partial<One>): One => {
@@ -635,38 +629,30 @@ export const aTwoAPI = (overrides?: Partial<Two>): Two => {
 });
 
 it('should convert to mocks hole json object', async () => {
-    const json = {
-        paths: {},
-        servers: {},
-        info: {},
-        components: {
-            schemas: {
-                One: {
-                    type: 'object',
-                    properties: {
-                        name: {
-                            type: 'string',
-                        },
-                    },
-                },
-                Two: {
-                    type: 'object',
-                    properties: {
-                        name: {
-                            type: 'number',
-                        },
-                    },
+    const json = swaggerV3Mock({
+        One: {
+            type: 'object',
+            properties: {
+                name: {
+                    type: 'string',
                 },
             },
         },
-    };
+        Two: {
+            type: 'object',
+            properties: {
+                name: {
+                    type: 'number',
+                },
+            },
+        },
+    });
 
     const result = await convertToMocks({
         json,
         fileName: 'doesnt matter',
         folderPath: './someFolder',
         typesPath: './pathToTypes',
-        swaggerVersion: 3,
     });
 
     const expectedString = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -692,77 +678,70 @@ export const aTwoAPI = (overrides?: Partial<Two>): Two => {
 });
 
 it('should generate mocks for "InviteAssetsMembersRequestDto" (multiple extends)', async () => {
-    const json = {
-        paths: {},
-        servers: {},
-        info: {},
-        components: {
-            schemas: {
-                MembersEmailDto: {
+    const json = swaggerV3Mock({
+        MembersEmailDto: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['members'],
+            properties: {
+                members: {
+                    type: 'array',
+                    items: {
+                        $ref: '#/components/schemas/MemberEmailDto',
+                    },
+                },
+            },
+        },
+        UserRole: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Owner', 'Collaborator', 'Viewer'],
+            enum: ['Owner', 'Collaborator', 'Viewer'],
+        },
+        InviteMembersRequestDto: {
+            allOf: [
+                {
+                    $ref: '#/components/schemas/MembersEmailDto',
+                },
+                {
                     type: 'object',
                     additionalProperties: false,
-                    required: ['members'],
+                    required: ['role'],
                     properties: {
-                        members: {
+                        message: {
+                            type: 'string',
+                            maxLength: 5000,
+                            nullable: true,
+                        },
+                        role: {
+                            $ref: '#/components/schemas/UserRole',
+                        },
+                    },
+                },
+            ],
+        },
+        InviteAssetsMembersRequestDto: {
+            allOf: [
+                {
+                    $ref: '#/components/schemas/InviteMembersRequestDto',
+                },
+                {
+                    type: 'object',
+                    additionalProperties: false,
+                    required: ['assetIds'],
+                    properties: {
+                        assetIds: {
                             type: 'array',
                             items: {
-                                $ref: '#/components/schemas/MemberEmailDto',
+                                type: 'string',
+                                format: 'guid',
                             },
                         },
                     },
                 },
-                UserRole: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': ['Owner', 'Collaborator', 'Viewer'],
-                    enum: ['Owner', 'Collaborator', 'Viewer'],
-                },
-                InviteMembersRequestDto: {
-                    allOf: [
-                        {
-                            $ref: '#/components/schemas/MembersEmailDto',
-                        },
-                        {
-                            type: 'object',
-                            additionalProperties: false,
-                            required: ['role'],
-                            properties: {
-                                message: {
-                                    type: 'string',
-                                    maxLength: 5000,
-                                    nullable: true,
-                                },
-                                role: {
-                                    $ref: '#/components/schemas/UserRole',
-                                },
-                            },
-                        },
-                    ],
-                },
-                InviteAssetsMembersRequestDto: {
-                    allOf: [
-                        {
-                            $ref: '#/components/schemas/InviteMembersRequestDto',
-                        },
-                        {
-                            type: 'object',
-                            additionalProperties: false,
-                            required: ['assetIds'],
-                            properties: {
-                                assetIds: {
-                                    type: 'array',
-                                    items: {
-                                        type: 'string',
-                                        format: 'guid',
-                                    },
-                                },
-                            },
-                        },
-                    ],
-                },
-            },
+            ],
         },
-    };
+    });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -801,33 +780,26 @@ export const anInviteAssetsMembersRequestDtoAPI = (overrides?: Partial<InviteAss
         fileName: "doesn't matter",
         folderPath: './someFolder',
         typesPath: './pathToTypes',
-        swaggerVersion: 3,
     });
 
     expect(result).toEqual(expected);
 });
 
 it('should generate mocks for "MemberEmailDto" (email property)', async () => {
-    const json = {
-        paths: {},
-        servers: {},
-        info: {},
-        components: {
-            schemas: {
-                MemberEmailDto: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        email: {
-                            type: 'string',
-                            format: 'email',
-                            nullable: true,
-                        },
-                    },
+    const json = swaggerV3Mock({
+        MemberEmailDto: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                email: {
+                    type: 'string',
+                    format: 'email',
+                    nullable: true,
                 },
             },
         },
-    };
+    });
+
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import {MemberEmailDto} from './pathToTypes';
@@ -846,58 +818,50 @@ export const aMemberEmailDtoAPI = (overrides?: Partial<MemberEmailDto>): MemberE
         fileName: "doesn't matter",
         folderPath: './someFolder',
         typesPath: './pathToTypes',
-        swaggerVersion: 3,
     });
 
     expect(result).toEqual(expected);
 });
 
 it('should generate mocks for "Comment" (duration property)', async () => {
-    const json = {
-        paths: {},
-        servers: {},
-        info: {},
-        components: {
-            schemas: {
-                Comment: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        id: {
-                            type: 'string',
-                            format: 'guid',
-                        },
-                        message: {
-                            type: 'string',
-                            nullable: true,
-                        },
-                        userId: {
-                            type: 'string',
-                            format: 'guid',
-                        },
-                        annotationTime: {
-                            type: 'string',
-                            format: 'time-span',
-                            nullable: true,
-                        },
-                        annotationDuration: {
-                            type: 'string',
-                            format: 'time-span',
-                            nullable: true,
-                        },
-                        creationTime: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                        lastModifiedTime: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                    },
+    const json = swaggerV3Mock({
+        Comment: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                id: {
+                    type: 'string',
+                    format: 'guid',
+                },
+                message: {
+                    type: 'string',
+                    nullable: true,
+                },
+                userId: {
+                    type: 'string',
+                    format: 'guid',
+                },
+                annotationTime: {
+                    type: 'string',
+                    format: 'time-span',
+                    nullable: true,
+                },
+                annotationDuration: {
+                    type: 'string',
+                    format: 'time-span',
+                    nullable: true,
+                },
+                creationTime: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+                lastModifiedTime: {
+                    type: 'string',
+                    format: 'date-time',
                 },
             },
         },
-    };
+    });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -923,36 +887,28 @@ export const aCommentAPI = (overrides?: Partial<Comment>): Comment => {
         fileName: "doesn't matter",
         folderPath: './someFolder',
         typesPath: './pathToTypes',
-        swaggerVersion: 3,
     });
 
     expect(result).toEqual(expected);
 });
 
 it('should generate mocks for array of integers', async () => {
-    const json = {
-        paths: {},
-        servers: {},
-        info: {},
-        components: {
-            schemas: {
-                ArrayOfIntegers: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        invoiceNumbers: {
-                            type: 'array',
-                            nullable: true,
-                            items: {
-                                type: 'integer',
-                                format: 'int64',
-                            },
-                        },
+    const json = swaggerV3Mock({
+        ArrayOfIntegers: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                invoiceNumbers: {
+                    type: 'array',
+                    nullable: true,
+                    items: {
+                        type: 'integer',
+                        format: 'int64',
                     },
                 },
             },
         },
-    };
+    });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -971,31 +927,23 @@ export const anArrayOfIntegersAPI = (overrides?: Partial<ArrayOfIntegers>): Arra
         fileName: "doesn't matter",
         folderPath: './someFolder',
         typesPath: './pathToTypes',
-        swaggerVersion: 3,
     });
 
     expect(result).toEqual(expected);
 });
 
 it('should generate mocks for a property without a "type"', async () => {
-    const json = {
-        paths: {},
-        servers: {},
-        info: {},
-        components: {
-            schemas: {
-                Notification: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        payload: {
-                            nullable: true,
-                        },
-                    },
+    const json = swaggerV3Mock({
+        Notification: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                payload: {
+                    nullable: true,
                 },
             },
         },
-    };
+    });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -1014,60 +962,52 @@ export const aNotificationAPI = (overrides?: Partial<Notification>): Notificatio
         fileName: "doesn't matter",
         folderPath: './someFolder',
         typesPath: './pathToTypes',
-        swaggerVersion: 3,
     });
 
     expect(result).toEqual(expected);
 });
 
 it('should generate mocks for a enum "dictionary" type', async () => {
-    const json = {
-        paths: {},
-        servers: {},
-        info: {},
-        components: {
-            schemas: {
-                BillingProviderKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': ['Legacy', 'Fusebill'],
-                    enum: ['Legacy', 'Fusebill'],
-                },
-                ServiceOfferKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
-                },
-                UserMetadata: {
+    const json = swaggerV3Mock({
+        BillingProviderKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Legacy', 'Fusebill'],
+            enum: ['Legacy', 'Fusebill'],
+        },
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+        },
+        UserMetadata: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                serviceOffers: {
                     type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        serviceOffers: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                $ref: '#/components/schemas/BillingProviderKind',
-                            },
-                        },
-                        copy: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                $ref: '#/components/schemas/BillingProviderKind',
-                            },
-                        },
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
+                    },
+                    additionalProperties: {
+                        $ref: '#/components/schemas/BillingProviderKind',
+                    },
+                },
+                copy: {
+                    type: 'object',
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
+                    },
+                    additionalProperties: {
+                        $ref: '#/components/schemas/BillingProviderKind',
                     },
                 },
             },
         },
-    };
+    });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -1099,79 +1039,71 @@ export const anUserMetadataAPI = (overrides?: Partial<UserMetadata>): UserMetada
         fileName: "doesn't matter",
         folderPath: './someFolder',
         typesPath: './pathToTypes',
-        swaggerVersion: 3,
     });
 
     expect(result).toEqual(expected);
 });
 
 it('should generate mocks for an object "dictionary" type', async () => {
-    const json = {
-        paths: {},
-        servers: {},
-        info: {},
-        components: {
-            schemas: {
-                ServiceOfferKind: {
+    const json = swaggerV3Mock({
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+        },
+        CurrentSubscription: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                creationDate: {
                     type: 'string',
-                    description: '',
-                    'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+                    format: 'date-time',
                 },
-                CurrentSubscription: {
+                activationDate: {
+                    type: 'string',
+                    format: 'date-time',
+                    nullable: true,
+                },
+            },
+        },
+        NextSubscription: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                startDate: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+            },
+        },
+        UserSubscriptions: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                current: {
                     type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        creationDate: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                        activationDate: {
-                            type: 'string',
-                            format: 'date-time',
-                            nullable: true,
-                        },
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
+                    },
+                    additionalProperties: {
+                        $ref: '#/components/schemas/CurrentSubscription',
                     },
                 },
-                NextSubscription: {
+                next: {
                     type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        startDate: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
                     },
-                },
-                UserSubscriptions: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        current: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                $ref: '#/components/schemas/CurrentSubscription',
-                            },
-                        },
-                        next: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                $ref: '#/components/schemas/NextSubscription',
-                            },
-                        },
+                    additionalProperties: {
+                        $ref: '#/components/schemas/NextSubscription',
                     },
                 },
             },
         },
-    };
+    });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -1218,95 +1150,87 @@ export const anUserSubscriptionsAPI = (overrides?: Partial<UserSubscriptions>): 
         fileName: "doesn't matter",
         folderPath: './someFolder',
         typesPath: './pathToTypes',
-        swaggerVersion: 3,
     });
 
     expect(result).toEqual(expected);
 });
 
 it('should generate mocks for a "dictionary" type boolean', async () => {
-    const json = {
-        paths: {},
-        servers: {},
-        info: {},
-        components: {
-            schemas: {
-                ContentDtoOfCollectionDto: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        data: {
-                            type: 'array',
-                            nullable: true,
-                            items: {
-                                $ref: '#/components/schemas/CollectionDto',
-                            },
-                        },
-                        paging: {
-                            nullable: true,
-                            oneOf: [
-                                {
-                                    $ref: '#/components/schemas/PagingOptionsDto',
-                                },
-                            ],
-                        },
+    const json = swaggerV3Mock({
+        ContentDtoOfCollectionDto: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                data: {
+                    type: 'array',
+                    nullable: true,
+                    items: {
+                        $ref: '#/components/schemas/CollectionDto',
                     },
                 },
-                CollectionDto: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        id: {
-                            type: 'string',
-                            format: 'guid',
+                paging: {
+                    nullable: true,
+                    oneOf: [
+                        {
+                            $ref: '#/components/schemas/PagingOptionsDto',
                         },
-                        ownerId: {
-                            type: 'string',
-                            format: 'guid',
-                        },
-                        name: {
-                            type: 'string',
-                            nullable: true,
-                        },
-                        creationTime: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                        lastModifiedTime: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                        isSoftDeleted: {
-                            type: 'boolean',
-                        },
-                        collaborators: {
-                            type: 'array',
-                            nullable: true,
-                            items: {
-                                $ref: '#/components/schemas/CollaboratorDto',
-                            },
-                        },
-                        permissions: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/UserOperation',
-                            },
-                            additionalProperties: {
-                                type: 'boolean',
-                            },
-                        },
-                    },
-                },
-                UserOperation: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': ['Read', 'Write'],
-                    enum: ['Read', 'Write'],
+                    ],
                 },
             },
         },
-    };
+        CollectionDto: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                id: {
+                    type: 'string',
+                    format: 'guid',
+                },
+                ownerId: {
+                    type: 'string',
+                    format: 'guid',
+                },
+                name: {
+                    type: 'string',
+                    nullable: true,
+                },
+                creationTime: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+                lastModifiedTime: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+                isSoftDeleted: {
+                    type: 'boolean',
+                },
+                collaborators: {
+                    type: 'array',
+                    nullable: true,
+                    items: {
+                        $ref: '#/components/schemas/CollaboratorDto',
+                    },
+                },
+                permissions: {
+                    type: 'object',
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/UserOperation',
+                    },
+                    additionalProperties: {
+                        type: 'boolean',
+                    },
+                },
+            },
+        },
+        UserOperation: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Read', 'Write'],
+            enum: ['Read', 'Write'],
+        },
+    });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -1343,57 +1267,42 @@ export const aCollectionDtoAPI = (overrides?: Partial<CollectionDto>): Collectio
         fileName: "doesn't matter",
         folderPath: './someFolder',
         typesPath: './pathToTypes',
-        swaggerVersion: 3,
     });
 
     expect(result).toEqual(expected);
 });
 
 it('should generate overrided mocks for dictionary enum type', async () => {
-    const json = {
-        paths: {},
-        servers: {},
-        info: {},
-        components: {
-            schemas: {
-                UserMetadata: {
+    const json = swaggerV3Mock({
+        UserMetadata: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                serviceOffers: {
                     type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        serviceOffers: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                $ref: '#/components/schemas/BillingProviderKind',
-                            },
-                        },
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
                     },
-                },
-                ServiceOfferKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': [
-                        'MasteringAndDistribution',
-                        'Video',
-                        'Samples',
-                        'Mastering',
-                        'Distribution',
-                        'Sessions',
-                    ],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
-                },
-                BillingProviderKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': ['Legacy', 'Fusebill'],
-                    enum: ['Legacy', 'Fusebill'],
+                    additionalProperties: {
+                        $ref: '#/components/schemas/BillingProviderKind',
+                    },
                 },
             },
         },
-    };
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+        },
+        BillingProviderKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Legacy', 'Fusebill'],
+            enum: ['Legacy', 'Fusebill'],
+        },
+    });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -1419,7 +1328,6 @@ export const anUserMetadataAPI = (overrides?: Partial<UserMetadata>): UserMetada
         fileName: "doesn't matter",
         folderPath: './someFolder',
         typesPath: './pathToTypes',
-        swaggerVersion: 3,
         overrideSchemas: [
             {
                 ServiceOfferKind: {
@@ -1435,42 +1343,28 @@ export const anUserMetadataAPI = (overrides?: Partial<UserMetadata>): UserMetada
 });
 
 it('should generate overrided mocks for oneOf enum type', async () => {
-    const json = {
-        paths: {},
-        servers: {},
-        info: {},
-        components: {
-            schemas: {
-                CurrentSubscription: {
-                    type: "object",
-                    additionalProperties: false,
-                    properties: {
-                        serviceOffer: {
-                            description: "the service offer of the subscription.",
-                            oneOf: [
-                                {
-                                    $ref: "#/components/schemas/ServiceOfferKind"
-                                }
-                            ]
+    const json = swaggerV3Mock({
+        CurrentSubscription: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                serviceOffer: {
+                    description: 'the service offer of the subscription.',
+                    oneOf: [
+                        {
+                            $ref: '#/components/schemas/ServiceOfferKind',
                         },
-                    }
-                },
-                ServiceOfferKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': [
-                        'MasteringAndDistribution',
-                        'Video',
-                        'Samples',
-                        'Mastering',
-                        'Distribution',
-                        'Sessions',
                     ],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
                 },
             },
         },
-    };
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+        },
+    });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -1489,7 +1383,6 @@ export const aCurrentSubscriptionAPI = (overrides?: Partial<CurrentSubscription>
         fileName: "doesn't matter",
         folderPath: './someFolder',
         typesPath: './pathToTypes',
-        swaggerVersion: 3,
         overrideSchemas: [
             {
                 ServiceOfferKind: {
@@ -1505,37 +1398,23 @@ export const aCurrentSubscriptionAPI = (overrides?: Partial<CurrentSubscription>
 });
 
 it('should generate overrided mocks for $ref enum type', async () => {
-    const json = {
-        paths: {},
-        servers: {},
-        info: {},
-        components: {
-            schemas: {
-                NextSubscription: {
-                    type: "object",
-                    additionalProperties: false,
-                    properties: {
-                        serviceOffer: {
-                            $ref: "#/components/schemas/ServiceOfferKind"
-                        },
-                    }
-                },
-                ServiceOfferKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': [
-                        'MasteringAndDistribution',
-                        'Video',
-                        'Samples',
-                        'Mastering',
-                        'Distribution',
-                        'Sessions',
-                    ],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+    const json = swaggerV3Mock({
+        NextSubscription: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                serviceOffer: {
+                    $ref: '#/components/schemas/ServiceOfferKind',
                 },
             },
         },
-    };
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+        },
+    });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -1554,7 +1433,6 @@ export const aNextSubscriptionAPI = (overrides?: Partial<NextSubscription>): Nex
         fileName: "doesn't matter",
         folderPath: './someFolder',
         typesPath: './pathToTypes',
-        swaggerVersion: 3,
         overrideSchemas: [
             {
                 ServiceOfferKind: {
@@ -1570,27 +1448,19 @@ export const aNextSubscriptionAPI = (overrides?: Partial<NextSubscription>): Nex
 });
 
 it('should generate mocks for a URI type', async () => {
-    const json = {
-        paths: {},
-        servers: {},
-        info: {},
-        components: {
-            schemas: {
-                DownloadDto: {
-                    type: "object",
-                    additionalProperties: false,
-                    properties: {
-                        url: {
-                            type: "string",
-                            format: "uri",
-                            nullable: true
-                        }
-                    }
+    const json = swaggerV3Mock({
+        DownloadDto: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                url: {
+                    type: 'string',
+                    format: 'uri',
+                    nullable: true,
                 },
             },
-
         },
-    };
+    });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -1609,8 +1479,61 @@ export const aDownloadDtoAPI = (overrides?: Partial<DownloadDto>): DownloadDto =
         fileName: "doesn't matter",
         folderPath: './someFolder',
         typesPath: './pathToTypes',
-        swaggerVersion: 3,
     });
 
     expect(result).toEqual(expected);
+});
+
+it('should return CollectionResponseDto mocks', async () => {
+    const json = swaggerV2Mock({
+        'CollectionResponseDto[StoredCreditCardDto]': {
+            title: 'CollectionResponse`1',
+            type: 'object',
+            properties: {
+                data: {
+                    type: 'array',
+                    items: {
+                        $ref: '#/definitions/StoredCreditCardDto',
+                    },
+                },
+            },
+        },
+        StoredCreditCardDto: {
+            title: 'StoredCreditCard',
+            type: 'object',
+            properties: {
+                creditCardId: {
+                    type: 'string',
+                },
+            },
+        },
+    });
+
+    const result = await convertToMocks({
+        json,
+        fileName: "doesn't matter",
+        folderPath: './someFolder',
+        typesPath: './pathToTypes',
+    });
+
+    const expectedString = `/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {CollectionResponseDto, StoredCreditCardDto} from './pathToTypes';
+
+export const aCollectionResponseDtoAPI = (overrides?: Partial<CollectionResponseDto>): CollectionResponseDto => {
+  return {
+    data: overrides?.data || [aStoredCreditCardDtoAPI()],
+  ...overrides,
+  };
+};
+
+export const aStoredCreditCardDtoAPI = (overrides?: Partial<StoredCreditCardDto>): StoredCreditCardDto => {
+  return {
+    creditCardId: 'creditCardId-storedcreditcarddto',
+  ...overrides,
+  };
+};
+ 
+`;
+    expect(result).toEqual(expectedString);
 });

--- a/tests/shared.test.ts
+++ b/tests/shared.test.ts
@@ -1,3 +1,5 @@
+import { swaggerV2Mock, swaggerV3Mock } from '../src/utils/test-utils';
+
 jest.mock('node-fetch');
 jest.mock('fs');
 
@@ -43,30 +45,26 @@ describe('TS types generation', () => {
     });
 
     it('should parse v2 schemas', async () => {
-        const json = {
-            paths: {},
-            securityDefinitions: {},
-            tags: {},
-            definitions: {
-                One: {
-                    type: 'object',
-                    properties: {
-                        name: {
-                            type: 'string',
-                        },
-                    },
-                },
-                Two: {
-                    type: 'object',
-                    properties: {
-                        name: {
-                            type: 'number',
-                        },
+        const json = swaggerV2Mock({
+            One: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'string',
                     },
                 },
             },
-        };
-        const parsedData = getSchemas({ json, swaggerVersion: 2 });
+            Two: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'number',
+                    },
+                },
+            },
+        });
+
+        const parsedData = getSchemas({ json });
 
         const expected = {
             One: {
@@ -90,32 +88,26 @@ describe('TS types generation', () => {
     });
 
     it('should parse v3 schemas', async () => {
-        const json = {
-            paths: {},
-            servers: {},
-            info: {},
-            components: {
-                schemas: {
-                    One: {
-                        type: 'object',
-                        properties: {
-                            name: {
-                                type: 'string',
-                            },
-                        },
-                    },
-                    Two: {
-                        type: 'object',
-                        properties: {
-                            name: {
-                                type: 'number',
-                            },
-                        },
+        const json = swaggerV3Mock({
+            One: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'string',
                     },
                 },
             },
-        };
-        const parsedData = getSchemas({ json, swaggerVersion: 3 });
+            Two: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'number',
+                    },
+                },
+            },
+        });
+
+        const parsedData = getSchemas({ json });
 
         const expected = {
             One: {
@@ -139,32 +131,26 @@ describe('TS types generation', () => {
     });
 
     it('should parse v3 schemas by default', async () => {
-        const json = {
-            paths: {},
-            servers: {},
-            info: {},
-            components: {
-                schemas: {
-                    One: {
-                        type: 'object',
-                        properties: {
-                            name: {
-                                type: 'string',
-                            },
-                        },
-                    },
-                    Two: {
-                        type: 'object',
-                        properties: {
-                            name: {
-                                type: 'number',
-                            },
-                        },
+        const json = swaggerV3Mock({
+            One: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'string',
                     },
                 },
             },
-        };
-        const parsedData = getSchemas({ json, swaggerVersion: undefined });
+            Two: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'number',
+                    },
+                },
+            },
+        });
+
+        const parsedData = getSchemas({ json });
 
         const expected = {
             One: {
@@ -188,13 +174,8 @@ describe('TS types generation', () => {
     });
 
     it('should return "undefined" json object in not valid', async () => {
-        const json = {
-            paths: {},
-            servers: {},
-            info: {},
-            components: {},
-        };
-        const parsedData = getSchemas({ json, swaggerVersion: undefined });
+        const json = swaggerV3Mock(undefined);
+        const parsedData = getSchemas({ json });
         expect(parsedData).toEqual(undefined);
     });
 

--- a/tests/typeConverter.test.ts
+++ b/tests/typeConverter.test.ts
@@ -1,4 +1,6 @@
 import { parseEnum, parseObject, parseSchemas } from '../src/typesConverter';
+import { SwaggerV2, SwaggerV3 } from '../src/types';
+import { swaggerV3Mock } from '../src/utils/test-utils';
 
 describe('TS types generation', () => {
     it('should convert id guid property', async () => {
@@ -451,97 +453,93 @@ export interface AssetDto {
     });
 
     it('should properly combine in one file', async () => {
-        const example = {
-            components: {
-                schemas: {
-                    AssetDto: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            id: {
-                                type: 'string',
-                                format: 'guid',
-                            },
-                            name: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                            type: {
-                                $ref: '#/components/schemas/AssetType',
-                            },
-                            files: {
-                                type: 'array',
-                                nullable: true,
-                                items: {
-                                    $ref: '#/components/schemas/AssetFileDto',
-                                },
-                            },
+        const json = swaggerV3Mock({
+            AssetDto: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    id: {
+                        type: 'string',
+                        format: 'guid',
+                    },
+                    name: {
+                        type: 'string',
+                        nullable: true,
+                    },
+                    type: {
+                        $ref: '#/components/schemas/AssetType',
+                    },
+                    files: {
+                        type: 'array',
+                        nullable: true,
+                        items: {
+                            $ref: '#/components/schemas/AssetFileDto',
                         },
-                    },
-                    AssetType: {
-                        type: 'string',
-                        description: '',
-                        'x-enumNames': ['Audio', 'Video', 'Image'],
-                        enum: ['Audio', 'Video', 'Image'],
-                    },
-                    AssetFileDto: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            state: {
-                                $ref: '#/components/schemas/FileState',
-                            },
-                            kind: {
-                                $ref: '#/components/schemas/FileKind',
-                            },
-                            creationTime: {
-                                type: 'string',
-                                format: 'date-time',
-                            },
-                            contentType: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                            hash: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                            location: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                            sizeBytes: {
-                                type: 'integer',
-                                format: 'int64',
-                            },
-                            duration: {
-                                type: 'number',
-                                format: 'double',
-                                nullable: true,
-                            },
-                            url: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                        },
-                    },
-                    FileState: {
-                        type: 'string',
-                        description: '',
-                        'x-enumNames': ['Created', 'Uploading', 'Processing', 'Failed', 'Available', 'Deleted'],
-                        enum: ['Created', 'Uploading', 'Processing', 'Failed', 'Available', 'Deleted'],
-                    },
-                    FileKind: {
-                        type: 'string',
-                        description: '',
-                        'x-enumNames': ['Original', 'Stream', 'Waveform'],
-                        enum: ['Original', 'Stream', 'Waveform'],
                     },
                 },
             },
-        };
+            AssetType: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Audio', 'Video', 'Image'],
+                enum: ['Audio', 'Video', 'Image'],
+            },
+            AssetFileDto: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    state: {
+                        $ref: '#/components/schemas/FileState',
+                    },
+                    kind: {
+                        $ref: '#/components/schemas/FileKind',
+                    },
+                    creationTime: {
+                        type: 'string',
+                        format: 'date-time',
+                    },
+                    contentType: {
+                        type: 'string',
+                        nullable: true,
+                    },
+                    hash: {
+                        type: 'string',
+                        nullable: true,
+                    },
+                    location: {
+                        type: 'string',
+                        nullable: true,
+                    },
+                    sizeBytes: {
+                        type: 'integer',
+                        format: 'int64',
+                    },
+                    duration: {
+                        type: 'number',
+                        format: 'double',
+                        nullable: true,
+                    },
+                    url: {
+                        type: 'string',
+                        nullable: true,
+                    },
+                },
+            },
+            FileState: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Created', 'Uploading', 'Processing', 'Failed', 'Available', 'Deleted'],
+                enum: ['Created', 'Uploading', 'Processing', 'Failed', 'Available', 'Deleted'],
+            },
+            FileKind: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Original', 'Stream', 'Waveform'],
+                enum: ['Original', 'Stream', 'Waveform'],
+            },
+        });
 
-        const resultString = parseSchemas({ json: example, swaggerVersion: 3 });
+        const resultString = parseSchemas({ json });
 
         const expectedString = `export interface AssetDto {
     id: string; // format: "guid"
@@ -569,19 +567,15 @@ export type FileKind = 'Original' | 'Stream' | 'Waveform';
     });
 
     it('should return TODO text if data type is wrong (catch block)', async () => {
-        const example = {
-            components: {
-                schemas: {
-                    FileState: {
-                        type: 'string',
-                        description: '',
-                        $ref: { wrongData: 'wrongData' },
-                    },
-                },
+        const json = swaggerV3Mock({
+            FileState: {
+                type: 'string',
+                description: '',
+                $ref: { wrongData: 'wrongData' },
             },
-        };
+        });
 
-        const resultString = parseSchemas({ json: example, swaggerVersion: 3 });
+        const resultString = parseSchemas({ json });
 
         const expectedString = '// TODO: ERROR! Something wrong with FileState \n \n';
 
@@ -589,41 +583,37 @@ export type FileKind = 'Original' | 'Stream' | 'Waveform';
     });
 
     it('should return TODO text if type was not converted', async () => {
-        const example = {
-            components: {
-                schemas: {
-                    AssetDto: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            id: {
-                                type: 'string',
-                                format: 'guid',
-                            },
-                            name: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                        },
+        const json = swaggerV3Mock({
+            AssetDto: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    id: {
+                        type: 'string',
+                        format: 'guid',
                     },
-                    WrongData: {
-                        type: 'foo',
-                    },
-                    AssetFileDto: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            creationTime: {
-                                type: 'string',
-                                format: 'date-time',
-                            },
-                        },
+                    name: {
+                        type: 'string',
+                        nullable: true,
                     },
                 },
             },
-        };
+            WrongData: {
+                type: 'foo',
+            },
+            AssetFileDto: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    creationTime: {
+                        type: 'string',
+                        format: 'date-time',
+                    },
+                },
+            },
+        });
 
-        const resultString = parseSchemas({ json: example, swaggerVersion: 3 });
+        const resultString = parseSchemas({ json });
 
         const expectedString = `export interface AssetDto {
     id: string; // format: "guid"
@@ -639,28 +629,24 @@ export interface AssetFileDto {
     });
 
     it('should return correct type for array of integers', async () => {
-        const example = {
-            components: {
-                schemas: {
-                    ArrayOfIntegers: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            invoiceNumbers: {
-                                type: 'array',
-                                nullable: true,
-                                items: {
-                                    type: 'integer',
-                                    format: 'int64',
-                                },
-                            },
+        const json = swaggerV3Mock({
+            ArrayOfIntegers: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    invoiceNumbers: {
+                        type: 'array',
+                        nullable: true,
+                        items: {
+                            type: 'integer',
+                            format: 'int64',
                         },
                     },
                 },
             },
-        };
+        });
 
-        const resultString = parseSchemas({ json: example, swaggerVersion: 3 });
+        const resultString = parseSchemas({ json });
 
         const expectedString = `export interface ArrayOfIntegers {
     invoiceNumbers?: number[];
@@ -671,7 +657,8 @@ export interface AssetFileDto {
     });
 
     it('should return "any" type for property without a type', async () => {
-        const example = {
+        const json: SwaggerV3 = {
+            openapi: '3.0.0',
             components: {
                 schemas: {
                     Notification: {
@@ -687,7 +674,7 @@ export interface AssetFileDto {
             },
         };
 
-        const resultString = parseSchemas({ json: example, swaggerVersion: 3 });
+        const resultString = parseSchemas({ json });
 
         const expectedString = `export interface Notification {
     payload?: any;
@@ -698,7 +685,8 @@ export interface AssetFileDto {
     });
 
     it('should return type for a "dictionary"', async () => {
-        const example = {
+        const json: SwaggerV3 = {
+            openapi: '3.0.0',
             components: {
                 schemas: {
                     BillingProviderKind: {
@@ -743,7 +731,7 @@ export interface AssetFileDto {
             },
         };
 
-        const resultString = parseSchemas({ json: example, swaggerVersion: 3 });
+        const resultString = parseSchemas({ json });
 
         const expectedString = `export type BillingProviderKind = 'Legacy' | 'Fusebill';
 export type ServiceOfferKind = 'MasteringAndDistribution' | 'Video' | 'Samples' | 'Mastering' | 'Distribution';
@@ -762,7 +750,8 @@ export interface UserMetadata {
 });
 
 it('should return type for a multiple "dictionary" types', async () => {
-    const example = {
+    const json: SwaggerV3 = {
+        openapi: '3.0.0',
         components: {
             schemas: {
                 BillingProviderKind: {
@@ -807,7 +796,7 @@ it('should return type for a multiple "dictionary" types', async () => {
         },
     };
 
-    const resultString = parseSchemas({ json: example, swaggerVersion: 3 });
+    const resultString = parseSchemas({ json });
 
     const expectedString = `export type BillingProviderKind = 'Legacy' | 'Fusebill';
 export type ServiceOfferKind = 'MasteringAndDistribution' | 'Video' | 'Samples' | 'Mastering' | 'Distribution';
@@ -825,90 +814,86 @@ export interface UserSubscriptions {
 });
 
 it('should return type for a "dictionary" type boolean', async () => {
-    const example = {
-        components: {
-            schemas: {
-                ContentDtoOfCollectionDto: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        data: {
-                            type: 'array',
-                            nullable: true,
-                            items: {
-                                $ref: '#/components/schemas/CollectionDto',
-                            },
-                        },
-                        paging: {
-                            nullable: true,
-                            oneOf: [
-                                {
-                                    $ref: '#/components/schemas/PagingOptionsDto',
-                                },
-                            ],
-                        },
+    const json = swaggerV3Mock({
+        ContentDtoOfCollectionDto: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                data: {
+                    type: 'array',
+                    nullable: true,
+                    items: {
+                        $ref: '#/components/schemas/CollectionDto',
                     },
                 },
-                CollectionDto: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        id: {
-                            type: 'string',
-                            format: 'guid',
+                paging: {
+                    nullable: true,
+                    oneOf: [
+                        {
+                            $ref: '#/components/schemas/PagingOptionsDto',
                         },
-                        ownerId: {
-                            type: 'string',
-                            format: 'guid',
-                        },
-                        name: {
-                            type: 'string',
-                            nullable: true,
-                        },
-                        type: {
-                            $ref: '#/components/schemas/CollectionType',
-                        },
-                        creationTime: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                        lastModifiedTime: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                        isSoftDeleted: {
-                            type: 'boolean',
-                        },
-                        collaborators: {
-                            type: 'array',
-                            nullable: true,
-                            items: {
-                                $ref: '#/components/schemas/CollaboratorDto',
-                            },
-                        },
-                        permissions: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/UserOperation',
-                            },
-                            additionalProperties: {
-                                type: 'boolean',
-                            },
-                        },
-                    },
-                },
-                UserOperation: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': ['Read', 'Write'],
-                    enum: ['Read', 'Write'],
+                    ],
                 },
             },
         },
-    };
+        CollectionDto: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                id: {
+                    type: 'string',
+                    format: 'guid',
+                },
+                ownerId: {
+                    type: 'string',
+                    format: 'guid',
+                },
+                name: {
+                    type: 'string',
+                    nullable: true,
+                },
+                type: {
+                    $ref: '#/components/schemas/CollectionType',
+                },
+                creationTime: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+                lastModifiedTime: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+                isSoftDeleted: {
+                    type: 'boolean',
+                },
+                collaborators: {
+                    type: 'array',
+                    nullable: true,
+                    items: {
+                        $ref: '#/components/schemas/CollaboratorDto',
+                    },
+                },
+                permissions: {
+                    type: 'object',
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/UserOperation',
+                    },
+                    additionalProperties: {
+                        type: 'boolean',
+                    },
+                },
+            },
+        },
+        UserOperation: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Read', 'Write'],
+            enum: ['Read', 'Write'],
+        },
+    });
 
-    const resultString = parseSchemas({ json: example, swaggerVersion: 3 });
+    const resultString = parseSchemas({ json });
 
     const expectedString = `export interface ContentDtoOfCollectionDto {
     data?: CollectionDto[];
@@ -935,29 +920,17 @@ export type UserOperation = 'Read' | 'Write';
 
 it('should return overrided enum schema', async () => {
     // What will be fetched from Swagger Json
-    const example = {
-        components: {
-            schemas: {
-                ServiceOfferKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': [
-                        'MasteringAndDistribution',
-                        'Video',
-                        'Samples',
-                        'Mastering',
-                        'Distribution',
-                        'Sessions',
-                    ],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
-                },
-            },
+    const json = swaggerV3Mock({
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
         },
-    };
+    });
 
     const resultString = parseSchemas({
-        json: example,
-        swaggerVersion: 3,
+        json,
         // Overrided value "ServiceOfferKind" enum
         overrideSchemas: [
             {
@@ -980,71 +953,64 @@ export type ServiceOfferKind = 'masteringAndDistribution' | 'video' | 'samples' 
 });
 
 it('should return description', async () => {
-    const example = {
-        components: {
-            schemas: {
-                PlanFrequencyIdentifier: {
+    const json = swaggerV3Mock({
+        PlanFrequencyIdentifier: {
+            type: 'object',
+            description: 'PlanFrequencyIdentifier description',
+            additionalProperties: false,
+            properties: {
+                code: {
+                    type: 'string',
+                    description: 'The Fusebill plan code.',
+                    nullable: true,
+                },
+                currentQuantity: {
+                    type: 'number',
+                    description: 'The current quantity of the product within the subscription.',
+                    format: 'decimal',
+                },
+                numberOfCredits: {
+                    type: 'integer',
+                    description: 'The number of credits associated to this subscription product.',
+                    format: 'int32',
+                    nullable: true,
+                },
+                frequency: {
+                    description: 'The interval of the plan (monthly/yearly).',
+                    oneOf: [
+                        {
+                            $ref: '#/components/schemas/Interval',
+                        },
+                    ],
+                },
+                hasOverduePayment: {
                     type: 'object',
-                    description: 'PlanFrequencyIdentifier description',
-                    additionalProperties: false,
-                    properties: {
-                        code: {
-                            type: 'string',
-                            description: 'The Fusebill plan code.',
-                            nullable: true,
-                        },
-                        currentQuantity: {
-                            type: 'number',
-                            description: 'The current quantity of the product within the subscription.',
-                            format: 'decimal',
-                        },
-                        numberOfCredits: {
-                            type: 'integer',
-                            description: 'The number of credits associated to this subscription product.',
-                            format: 'int32',
-                            nullable: true,
-                        },
-                        frequency: {
-                            description: 'The interval of the plan (monthly/yearly).',
-                            oneOf: [
-                                {
-                                    $ref: '#/components/schemas/Interval',
-                                },
-                            ],
-                        },
-                        hasOverduePayment: {
-                            type: 'object',
-                            description: 'Says if the user has overdue payments by service offer.',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                type: 'boolean',
-                            },
-                        },
-                        userIds: {
-                            type: 'array',
-                            description: 'The user IDs.',
-                            items: {
-                                type: 'string',
-                                format: 'guid',
-                            },
-                        },
-                        isDefault: {
-                            type: 'boolean',
-                            description: 'Boolean description',
-                        },
+                    description: 'Says if the user has overdue payments by service offer.',
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
                     },
+                    additionalProperties: {
+                        type: 'boolean',
+                    },
+                },
+                userIds: {
+                    type: 'array',
+                    description: 'The user IDs.',
+                    items: {
+                        type: 'string',
+                        format: 'guid',
+                    },
+                },
+                isDefault: {
+                    type: 'boolean',
+                    description: 'Boolean description',
                 },
             },
         },
-    };
-
-    const resultString = parseSchemas({
-        json: example,
-        swaggerVersion: 3,
     });
+
+    const resultString = parseSchemas({ json });
 
     const expectedString = `/**
  * PlanFrequencyIdentifier description 
@@ -1087,7 +1053,8 @@ export interface PlanFrequencyIdentifier {
 });
 
 it('should return CollectionResponseDto', async () => {
-    const example = {
+    const json = {
+        swagger: '2.0',
         definitions: {
             'CollectionResponseDto[StoredCreditCardDto]': {
                 title: 'CollectionResponse`1',
@@ -1105,12 +1072,9 @@ it('should return CollectionResponseDto', async () => {
                 },
             },
         },
-    };
+    } as SwaggerV2;
 
-    const resultString = parseSchemas({
-        json: example,
-        swaggerVersion: 2,
-    });
+    const resultString = parseSchemas({ json });
 
     const expectedString = `export interface CollectionResponseDto {
     data: StoredCreditCardDto[];


### PR DESCRIPTION
## 📄  Description
Fixed mocks codegen for the Swagger v2 version `Type[AnotherType]` annotation:
![2020-12-02_20-02-50](https://user-images.githubusercontent.com/22501553/100914060-3bc23e80-34db-11eb-88fa-4221c5355658.jpg)
![2020-12-02_20-15-24](https://user-images.githubusercontent.com/22501553/100914065-3cf36b80-34db-11eb-97f9-1e8982c5087b.jpg)

- One new additional test was added: https://github.com/LandrAudio/openapi-codegen-typescript/blob/c483870b31b0cccc55d140033cd7cc5dccfe1c21/tests/mockConverter.test.ts#L1487-L1539
- Updated `mockConverter.ts`: https://github.com/LandrAudio/openapi-codegen-typescript/blob/c483870b31b0cccc55d140033cd7cc5dccfe1c21/src/mockConverter.ts#L252-L261 

Removed requirement of specifying  swagger version (with updating `README.md` file) - now it is set up after json fetch:
- Updated `shared.ts` file: https://github.com/LandrAudio/openapi-codegen-typescript/blob/c483870b31b0cccc55d140033cd7cc5dccfe1c21/src/shared.ts#L75-L91

### All other changes are related to test refactors with use of test-utils.ts:https://github.com/LandrAudio/openapi-codegen-typescript/blob/c483870b31b0cccc55d140033cd7cc5dccfe1c21/src/utils/test-utils.ts#L1-L17

## 📦  Changes

## ⛰️  Screenshots/Videos

## ✅  Checklist
- [x] Contains no duplicate/temporary code
- [x] Contains no sensitive information
- [ ] Error handling added
- [x] Unit tests added

## 🔗  JIRA Issue
https://mixgenius.atlassian.net/browse/CHFE-789
