### PR TITLE
fix(type): fix mocks codegen for the Swagger v2 version `Type[AnotherType]` annotation (part 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,12 @@ const { fetchSwaggerJsonFile, convertToTypes } = require('openapi-codegen-typesc
 
 async function doSomething() {
   const json = await fetchSwaggerJsonFile('https://custom/swagger.json');
-  convertToTypes({ json, fileName: 'dtoAPI', folderPath: 'src/types/generated', swaggerVersion: 3 });
+  convertToTypes({ json, fileName: 'dtoAPI', folderPath: 'src/types/generated' });
 }
 ```
 
 This function ('doSomething()') fetches json file from urls, then converts json
 to typescript "types" and writes "types" to file ('src/types/generated/dtoAPI')
-If "swaggerVersion" will not be provided - it will be set to "3" by default.
 
 - For generating mock files that are using converted types
 
@@ -52,15 +51,13 @@ async function doSomething() {
     json,
     fileName: 'dtoAPI',
     folderPath: 'src/mocks/generated',
-    typesPath: '../../types/generated/dtoAPI',
-    swaggerVersion: 3,
+    typesPath: '../../types/generated/dtoAPI'
   });
 }
 ```
 
 This function ('doSomething()') fetches json file from urls, then converts json to "mocks" and writes "mocks" to file
 ('src/mocks/generated/dtoAPI') with imports from typescript types ('src/types/generated/dtoAPI')
-If "swaggerVersion" will not be provided - it will be set to "3" by default.
 
 ## Overriding enum schema type
 
@@ -102,15 +99,13 @@ async function main() {
     json,
     fileName: 'typesAPI',
     folderPath: 'src/types/generated',
-    swaggerVersion: 3,
-    overrideSchemas,
+    overrideSchemas
   });
   convertToMocks({
     json,
     fileName: 'mocksAPI',
     folderPath: 'src/mocks/generated',
-    typesPath: '../../types/generated/typesAPI',
-    swaggerVersion: 3,
+    typesPath: '../../types/generated/typesAPI'
   });
 }
 
@@ -126,13 +121,12 @@ const petShopLink = 'https://petstore.swagger.io/v2/swagger.json';
 
 async function main() {
   const json = await fetchSwaggerJsonFile(petShopLink);
-  convertToTypes({ json, fileName: 'typesAPI', folderPath: 'src/types/generated', swaggerVersion: 3 });
+  convertToTypes({ json, fileName: 'typesAPI', folderPath: 'src/types/generated' });
   convertToMocks({
     json,
     fileName: 'mocksAPI',
     folderPath: 'src/mocks/generated',
-    typesPath: '../../types/generated/typesAPI',
-    swaggerVersion: 3,
+    typesPath: '../../types/generated/typesAPI'
   });
 }
 
@@ -147,22 +141,20 @@ main();
 
 Returns a swagger json object;
 
-#### convertToTypes({ json, fileName, folderPath, swaggerVersion })
+#### convertToTypes({ json, fileName, folderPath })
 
 `json`: `object` - swagger json data;
 `fileName`: `string` - name of the file, where typescript types data will be saved;
 `folderPath`: `string` - folder path the `fileName`, where typescript types data will be saved;
-`swaggerVersion`: `number` - version of the swagger json file (specification). `3` by default;
 
 Returns `void`;
 
-#### convertToMocks({ json, fileName, folderPath, typesPath, swaggerVersion })
+#### convertToMocks({ json, fileName, folderPath, typesPath })
 
 `json`: `object` - swagger json data;
 `fileName`: `string` - name of the file, where mocks data will be saved;
 `folderPath`: `string` - folder path the `fileName`, where mocks data will be saved;
 `typesPath`: `string` - folder path to `types`, where typescript types data are saved.
 Path to `types` will be inserted to the type imports in generated mocks (generated -> import {...} from `typesPath`;);
-`swaggerVersion`: `number` - version of the swagger json file (specification);
 
 Returns `void`;

--- a/src/mockConverter.ts
+++ b/src/mockConverter.ts
@@ -1,5 +1,5 @@
 import { ConvertToMocksProps, DataTypes, EnumSchema, GetSchemasProps, MockArrayProps, SwaggerProps } from './types';
-import { getSchemaProperties, getSchemas, hashedString, writeToFile } from './shared';
+import { getSchemaProperties, getSchemas, hashedString, isSwaggerV2, writeToFile } from './shared';
 import casual from 'casual';
 import { MockGenerateHelper } from './MockGenerateHelper';
 
@@ -214,8 +214,8 @@ export const parseSchema = ({ schema, name, DTOs, overrideSchemas }: ParseSchema
     }
 };
 
-export const parseSchemas = ({ json, swaggerVersion, overrideSchemas }: GetSchemasProps) => {
-    const schemas = getSchemas({ json, swaggerVersion });
+export const parseSchemas = ({ json, overrideSchemas }: GetSchemasProps) => {
+    const schemas = getSchemas({ json });
     const DTOs = Object.keys(schemas);
 
     let resultString = '';
@@ -245,15 +245,14 @@ export const convertToMocks = ({
     fileName,
     folderPath,
     typesPath,
-    swaggerVersion = 3,
     overrideSchemas,
 }: ConvertToMocksProps): string => {
-    const schemas = getSchemas({ json, swaggerVersion });
+    const schemas = getSchemas({ json });
 
     const imports = Object.keys(schemas)
         .map(dtoName => {
             // Sometimes in swagger 2.0 version could be such name as SomeDto[AnotherDto]
-            if (swaggerVersion === 2 && dtoName.includes('[') && dtoName.includes(']')) {
+            if (isSwaggerV2(json) && dtoName.includes('[') && dtoName.includes(']')) {
                 return dtoName.split('[')[0];
             } else {
                 return dtoName;
@@ -265,7 +264,7 @@ export const convertToMocks = ({
     const disableNoUsedVars = '/* eslint-disable @typescript-eslint/no-unused-vars */\n';
     const importsDescription = `import {${imports}} from '${typesPath}';\n`;
 
-    const result = parseSchemas({ json, swaggerVersion, overrideSchemas });
+    const result = parseSchemas({ json, overrideSchemas });
 
     const resultString = `${disableNoUse}${disableNoUsedVars}${importsDescription}${result}`;
 

--- a/src/mockConverter.ts
+++ b/src/mockConverter.ts
@@ -94,7 +94,7 @@ interface ParseSchemaProps {
      * DTO name
      * Examples: MembersEmailDto, InviteMembersRequestDto, InviteAssetsMembersRequestDto
      */
-    name: any;
+    name: string;
     /**
      * All parsed DTOs from swagger json file
      */
@@ -129,6 +129,11 @@ export const parseSchema = ({ schema, name, DTOs, overrideSchemas }: ParseSchema
                     xDictionaryKey,
                     additionalProperties,
                 } = props;
+
+                if (name.includes('[') && name.includes(']')) {
+                    name = name.split('[')[0];
+                }
+
                 casual.seed(hashedString(name + propertyName));
 
                 const mockGenerator = new MockGenerateHelper(casual);
@@ -245,7 +250,16 @@ export const convertToMocks = ({
 }: ConvertToMocksProps): string => {
     const schemas = getSchemas({ json, swaggerVersion });
 
-    const imports = Object.keys(schemas).join(', ');
+    const imports = Object.keys(schemas)
+        .map(dtoName => {
+            // Sometimes in swagger 2.0 version could be such name as SomeDto[AnotherDto]
+            if (swaggerVersion === 2 && dtoName.includes('[') && dtoName.includes(']')) {
+                return dtoName.split('[')[0];
+            } else {
+                return dtoName;
+            }
+        })
+        .join(', ');
 
     const disableNoUse = '/* eslint-disable @typescript-eslint/no-use-before-define */\n';
     const disableNoUsedVars = '/* eslint-disable @typescript-eslint/no-unused-vars */\n';

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,4 +1,4 @@
-import { GetSchemasProps } from './types';
+import { GetSchemasProps, SwaggerV2, SwaggerV3 } from './types';
 
 const fs = require('fs');
 const fetch = require('node-fetch');
@@ -72,14 +72,21 @@ export const hashedString = (string: string) => {
     return hash;
 };
 
-export const getSchemas = ({ json, swaggerVersion = 3 }: GetSchemasProps) => {
-    switch (swaggerVersion) {
-        case 3:
-            return json?.components?.schemas;
-        case 2:
-            return json?.definitions;
-        default:
-            return json?.components?.schemas;
+export function isSwaggerV3(json: SwaggerV2 | SwaggerV3): json is SwaggerV3 {
+    return Boolean((json as SwaggerV3).openapi?.match(/^3.*/)) && Boolean((json as SwaggerV3).components);
+}
+
+export function isSwaggerV2(json: SwaggerV2 | SwaggerV3): json is SwaggerV2 {
+    return Boolean((json as SwaggerV2).swagger?.match(/^2.*/)) && Boolean((json as SwaggerV2).definitions);
+}
+
+export const getSchemas = ({ json }: GetSchemasProps): any => {
+    if (isSwaggerV3(json)) {
+        return json?.components?.schemas;
+    } else if (isSwaggerV2(json)) {
+        return json?.definitions;
+    } else {
+        throw Error('Schema parse exception. Unsupported version');
     }
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,22 +79,29 @@ export interface ConvertToTypesProps {
     json: any;
     fileName: string;
     folderPath: string;
-    swaggerVersion: number;
     overrideSchemas?: Array<EnumSchema>;
 }
 
 export interface ConvertToMocksProps {
-    json: any;
+    json: SwaggerV2 | SwaggerV3;
     fileName: string;
     folderPath: string;
     typesPath: string;
-    swaggerVersion: number;
     overrideSchemas?: Array<EnumSchema>;
 }
 
+export interface SwaggerV2 {
+    swagger: '2.0'; // "2.0"
+    definitions?: any;
+}
+
+export interface SwaggerV3 {
+    openapi: '3.0.0'; // "3.0.0",
+    components?: { schemas?: any };
+}
+
 export interface GetSchemasProps {
-    json: { components?: { schemas?: any }; definitions?: any };
-    swaggerVersion?: number;
+    json: SwaggerV2 | SwaggerV3;
     overrideSchemas?: Array<EnumSchema>;
 }
 

--- a/src/typesConverter.ts
+++ b/src/typesConverter.ts
@@ -13,7 +13,7 @@ import {
     ConvertToTypesProps,
     GetSchemasProps,
 } from './types';
-import { getSchemaProperties, getSchemas, writeToFile } from './shared';
+import { getSchemaProperties, getSchemas, isSwaggerV2, writeToFile } from './shared';
 
 const parseFormat = (format?: string): string => (format ? `format: "${format}"` : '');
 const parseRefType = (refType: string[]): string => refType[refType.length - 1];
@@ -324,8 +324,8 @@ export const parseEnum = ({ schema, schemaKey }: ParseProps): string => {
     return result;
 };
 
-export const parseSchemas = ({ json, swaggerVersion, overrideSchemas }: GetSchemasProps) => {
-    const schemas = getSchemas({ json, swaggerVersion });
+export const parseSchemas = ({ json, overrideSchemas }: GetSchemasProps) => {
+    const schemas = getSchemas({ json });
 
     if (schemas) {
         const schemasKeys = Object.keys(schemas);
@@ -341,7 +341,7 @@ export const parseSchemas = ({ json, swaggerVersion, overrideSchemas }: GetSchem
                     /**
                      * Sometimes in swagger v2 schema key could be named as SomeDto[AnotherDto]
                      */
-                    if (swaggerVersion === 2 && schemaKey.includes('[') && schemaKey.includes(']')) {
+                    if (isSwaggerV2(json) && schemaKey.includes('[') && schemaKey.includes(']')) {
                         const strings = schemaKey.split('[');
                         result += parseObject({ schema, schemaKey: strings[0] });
                     } else {
@@ -375,14 +375,8 @@ export const parseSchemas = ({ json, swaggerVersion, overrideSchemas }: GetSchem
     }
 };
 
-export const convertToTypes = ({
-    json,
-    fileName,
-    folderPath,
-    swaggerVersion,
-    overrideSchemas,
-}: ConvertToTypesProps) => {
-    const resultString = parseSchemas({ json, swaggerVersion, overrideSchemas });
+export const convertToTypes = ({ json, fileName, folderPath, overrideSchemas }: ConvertToTypesProps) => {
+    const resultString = parseSchemas({ json, overrideSchemas });
     writeToFile({
         folderPath,
         fileName,

--- a/src/utils/test-utils.ts
+++ b/src/utils/test-utils.ts
@@ -1,0 +1,17 @@
+import { SwaggerV2, SwaggerV3 } from '../types';
+
+export const aSwaggerV3Mock = (schemas: any): SwaggerV3 => {
+    return {
+        openapi: '3.0.0',
+        components: {
+            schemas,
+        },
+    };
+};
+
+export const aSwaggerV2Mock = (definitions: any): SwaggerV2 => {
+    return {
+        swagger: '2.0',
+        definitions,
+    };
+};

--- a/tests/mockConverter.test.ts
+++ b/tests/mockConverter.test.ts
@@ -1614,3 +1614,60 @@ export const aDownloadDtoAPI = (overrides?: Partial<DownloadDto>): DownloadDto =
 
     expect(result).toEqual(expected);
 });
+
+it('should return CollectionResponseDto mocks', async () => {
+    const json = {
+        definitions: {
+            'CollectionResponseDto[StoredCreditCardDto]': {
+                title: 'CollectionResponse`1',
+                type: 'object',
+                properties: {
+                    data: {
+                        type: 'array',
+                        items: {
+                            $ref: '#/definitions/StoredCreditCardDto',
+                        },
+                    },
+                },
+            },
+            StoredCreditCardDto: {
+                title: 'StoredCreditCard',
+                type: 'object',
+                properties: {
+                    creditCardId: {
+                        type: 'string',
+                    },
+                },
+            },
+        }
+    };
+
+    const result = await convertToMocks({
+        json,
+        fileName: "doesn't matter",
+        folderPath: './someFolder',
+        typesPath: './pathToTypes',
+        swaggerVersion: 2
+    });
+
+    const expectedString = `/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {CollectionResponseDto, StoredCreditCardDto} from './pathToTypes';
+
+export const aCollectionResponseDtoAPI = (overrides?: Partial<CollectionResponseDto>): CollectionResponseDto => {
+  return {
+    data: overrides?.data || [aStoredCreditCardDtoAPI()],
+  ...overrides,
+  };
+};
+
+export const aStoredCreditCardDtoAPI = (overrides?: Partial<StoredCreditCardDto>): StoredCreditCardDto => {
+  return {
+    creditCardId: 'creditCardId-storedcreditcarddto',
+  ...overrides,
+  };
+};
+ 
+`;
+    expect(result).toEqual(expectedString);
+});

--- a/tests/shared.test.ts
+++ b/tests/shared.test.ts
@@ -1,3 +1,5 @@
+import { aSwaggerV2Mock, aSwaggerV3Mock } from '../src/utils/test-utils';
+
 jest.mock('node-fetch');
 jest.mock('fs');
 
@@ -43,30 +45,26 @@ describe('TS types generation', () => {
     });
 
     it('should parse v2 schemas', async () => {
-        const json = {
-            paths: {},
-            securityDefinitions: {},
-            tags: {},
-            definitions: {
-                One: {
-                    type: 'object',
-                    properties: {
-                        name: {
-                            type: 'string',
-                        },
-                    },
-                },
-                Two: {
-                    type: 'object',
-                    properties: {
-                        name: {
-                            type: 'number',
-                        },
+        const json = aSwaggerV2Mock({
+            One: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'string',
                     },
                 },
             },
-        };
-        const parsedData = getSchemas({ json, swaggerVersion: 2 });
+            Two: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'number',
+                    },
+                },
+            },
+        });
+
+        const parsedData = getSchemas({ json });
 
         const expected = {
             One: {
@@ -90,32 +88,26 @@ describe('TS types generation', () => {
     });
 
     it('should parse v3 schemas', async () => {
-        const json = {
-            paths: {},
-            servers: {},
-            info: {},
-            components: {
-                schemas: {
-                    One: {
-                        type: 'object',
-                        properties: {
-                            name: {
-                                type: 'string',
-                            },
-                        },
-                    },
-                    Two: {
-                        type: 'object',
-                        properties: {
-                            name: {
-                                type: 'number',
-                            },
-                        },
+        const json = aSwaggerV3Mock({
+            One: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'string',
                     },
                 },
             },
-        };
-        const parsedData = getSchemas({ json, swaggerVersion: 3 });
+            Two: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'number',
+                    },
+                },
+            },
+        });
+
+        const parsedData = getSchemas({ json });
 
         const expected = {
             One: {
@@ -139,32 +131,26 @@ describe('TS types generation', () => {
     });
 
     it('should parse v3 schemas by default', async () => {
-        const json = {
-            paths: {},
-            servers: {},
-            info: {},
-            components: {
-                schemas: {
-                    One: {
-                        type: 'object',
-                        properties: {
-                            name: {
-                                type: 'string',
-                            },
-                        },
-                    },
-                    Two: {
-                        type: 'object',
-                        properties: {
-                            name: {
-                                type: 'number',
-                            },
-                        },
+        const json = aSwaggerV3Mock({
+            One: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'string',
                     },
                 },
             },
-        };
-        const parsedData = getSchemas({ json, swaggerVersion: undefined });
+            Two: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'number',
+                    },
+                },
+            },
+        });
+
+        const parsedData = getSchemas({ json });
 
         const expected = {
             One: {
@@ -188,13 +174,8 @@ describe('TS types generation', () => {
     });
 
     it('should return "undefined" json object in not valid', async () => {
-        const json = {
-            paths: {},
-            servers: {},
-            info: {},
-            components: {},
-        };
-        const parsedData = getSchemas({ json, swaggerVersion: undefined });
+        const json = aSwaggerV3Mock(undefined);
+        const parsedData = getSchemas({ json });
         expect(parsedData).toEqual(undefined);
     });
 

--- a/tests/typeConverter.test.ts
+++ b/tests/typeConverter.test.ts
@@ -1,4 +1,5 @@
 import { parseEnum, parseObject, parseSchemas } from '../src/typesConverter';
+import { aSwaggerV2Mock, aSwaggerV3Mock } from '../src/utils/test-utils';
 
 describe('TS types generation', () => {
     it('should convert id guid property', async () => {
@@ -451,97 +452,93 @@ export interface AssetDto {
     });
 
     it('should properly combine in one file', async () => {
-        const example = {
-            components: {
-                schemas: {
-                    AssetDto: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            id: {
-                                type: 'string',
-                                format: 'guid',
-                            },
-                            name: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                            type: {
-                                $ref: '#/components/schemas/AssetType',
-                            },
-                            files: {
-                                type: 'array',
-                                nullable: true,
-                                items: {
-                                    $ref: '#/components/schemas/AssetFileDto',
-                                },
-                            },
+        const json = aSwaggerV3Mock({
+            AssetDto: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    id: {
+                        type: 'string',
+                        format: 'guid',
+                    },
+                    name: {
+                        type: 'string',
+                        nullable: true,
+                    },
+                    type: {
+                        $ref: '#/components/schemas/AssetType',
+                    },
+                    files: {
+                        type: 'array',
+                        nullable: true,
+                        items: {
+                            $ref: '#/components/schemas/AssetFileDto',
                         },
-                    },
-                    AssetType: {
-                        type: 'string',
-                        description: '',
-                        'x-enumNames': ['Audio', 'Video', 'Image'],
-                        enum: ['Audio', 'Video', 'Image'],
-                    },
-                    AssetFileDto: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            state: {
-                                $ref: '#/components/schemas/FileState',
-                            },
-                            kind: {
-                                $ref: '#/components/schemas/FileKind',
-                            },
-                            creationTime: {
-                                type: 'string',
-                                format: 'date-time',
-                            },
-                            contentType: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                            hash: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                            location: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                            sizeBytes: {
-                                type: 'integer',
-                                format: 'int64',
-                            },
-                            duration: {
-                                type: 'number',
-                                format: 'double',
-                                nullable: true,
-                            },
-                            url: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                        },
-                    },
-                    FileState: {
-                        type: 'string',
-                        description: '',
-                        'x-enumNames': ['Created', 'Uploading', 'Processing', 'Failed', 'Available', 'Deleted'],
-                        enum: ['Created', 'Uploading', 'Processing', 'Failed', 'Available', 'Deleted'],
-                    },
-                    FileKind: {
-                        type: 'string',
-                        description: '',
-                        'x-enumNames': ['Original', 'Stream', 'Waveform'],
-                        enum: ['Original', 'Stream', 'Waveform'],
                     },
                 },
             },
-        };
+            AssetType: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Audio', 'Video', 'Image'],
+                enum: ['Audio', 'Video', 'Image'],
+            },
+            AssetFileDto: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    state: {
+                        $ref: '#/components/schemas/FileState',
+                    },
+                    kind: {
+                        $ref: '#/components/schemas/FileKind',
+                    },
+                    creationTime: {
+                        type: 'string',
+                        format: 'date-time',
+                    },
+                    contentType: {
+                        type: 'string',
+                        nullable: true,
+                    },
+                    hash: {
+                        type: 'string',
+                        nullable: true,
+                    },
+                    location: {
+                        type: 'string',
+                        nullable: true,
+                    },
+                    sizeBytes: {
+                        type: 'integer',
+                        format: 'int64',
+                    },
+                    duration: {
+                        type: 'number',
+                        format: 'double',
+                        nullable: true,
+                    },
+                    url: {
+                        type: 'string',
+                        nullable: true,
+                    },
+                },
+            },
+            FileState: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Created', 'Uploading', 'Processing', 'Failed', 'Available', 'Deleted'],
+                enum: ['Created', 'Uploading', 'Processing', 'Failed', 'Available', 'Deleted'],
+            },
+            FileKind: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Original', 'Stream', 'Waveform'],
+                enum: ['Original', 'Stream', 'Waveform'],
+            },
+        });
 
-        const resultString = parseSchemas({ json: example, swaggerVersion: 3 });
+        const resultString = parseSchemas({ json });
 
         const expectedString = `export interface AssetDto {
     id: string; // format: "guid"
@@ -569,19 +566,15 @@ export type FileKind = 'Original' | 'Stream' | 'Waveform';
     });
 
     it('should return TODO text if data type is wrong (catch block)', async () => {
-        const example = {
-            components: {
-                schemas: {
-                    FileState: {
-                        type: 'string',
-                        description: '',
-                        $ref: { wrongData: 'wrongData' },
-                    },
-                },
+        const json = aSwaggerV3Mock({
+            FileState: {
+                type: 'string',
+                description: '',
+                $ref: { wrongData: 'wrongData' },
             },
-        };
+        });
 
-        const resultString = parseSchemas({ json: example, swaggerVersion: 3 });
+        const resultString = parseSchemas({ json });
 
         const expectedString = '// TODO: ERROR! Something wrong with FileState \n \n';
 
@@ -589,41 +582,37 @@ export type FileKind = 'Original' | 'Stream' | 'Waveform';
     });
 
     it('should return TODO text if type was not converted', async () => {
-        const example = {
-            components: {
-                schemas: {
-                    AssetDto: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            id: {
-                                type: 'string',
-                                format: 'guid',
-                            },
-                            name: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                        },
+        const json = aSwaggerV3Mock({
+            AssetDto: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    id: {
+                        type: 'string',
+                        format: 'guid',
                     },
-                    WrongData: {
-                        type: 'foo',
-                    },
-                    AssetFileDto: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            creationTime: {
-                                type: 'string',
-                                format: 'date-time',
-                            },
-                        },
+                    name: {
+                        type: 'string',
+                        nullable: true,
                     },
                 },
             },
-        };
+            WrongData: {
+                type: 'foo',
+            },
+            AssetFileDto: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    creationTime: {
+                        type: 'string',
+                        format: 'date-time',
+                    },
+                },
+            },
+        });
 
-        const resultString = parseSchemas({ json: example, swaggerVersion: 3 });
+        const resultString = parseSchemas({ json });
 
         const expectedString = `export interface AssetDto {
     id: string; // format: "guid"
@@ -639,28 +628,24 @@ export interface AssetFileDto {
     });
 
     it('should return correct type for array of integers', async () => {
-        const example = {
-            components: {
-                schemas: {
-                    ArrayOfIntegers: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            invoiceNumbers: {
-                                type: 'array',
-                                nullable: true,
-                                items: {
-                                    type: 'integer',
-                                    format: 'int64',
-                                },
-                            },
+        const json = aSwaggerV3Mock({
+            ArrayOfIntegers: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    invoiceNumbers: {
+                        type: 'array',
+                        nullable: true,
+                        items: {
+                            type: 'integer',
+                            format: 'int64',
                         },
                     },
                 },
             },
-        };
+        });
 
-        const resultString = parseSchemas({ json: example, swaggerVersion: 3 });
+        const resultString = parseSchemas({ json });
 
         const expectedString = `export interface ArrayOfIntegers {
     invoiceNumbers?: number[];
@@ -671,23 +656,19 @@ export interface AssetFileDto {
     });
 
     it('should return "any" type for property without a type', async () => {
-        const example = {
-            components: {
-                schemas: {
-                    Notification: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            payload: {
-                                nullable: true,
-                            },
-                        },
+        const json = aSwaggerV3Mock({
+            Notification: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    payload: {
+                        nullable: true,
                     },
                 },
             },
-        };
+        });
 
-        const resultString = parseSchemas({ json: example, swaggerVersion: 3 });
+        const resultString = parseSchemas({ json });
 
         const expectedString = `export interface Notification {
     payload?: any;
@@ -698,52 +679,48 @@ export interface AssetFileDto {
     });
 
     it('should return type for a "dictionary"', async () => {
-        const example = {
-            components: {
-                schemas: {
-                    BillingProviderKind: {
-                        type: 'string',
-                        description: '',
-                        'x-enumNames': ['Legacy', 'Fusebill'],
-                        enum: ['Legacy', 'Fusebill'],
-                    },
-                    ServiceOfferKind: {
-                        type: 'string',
-                        description: '',
-                        'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
-                        enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
-                    },
-                    UserMetadata: {
+        const json = aSwaggerV3Mock({
+            BillingProviderKind: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Legacy', 'Fusebill'],
+                enum: ['Legacy', 'Fusebill'],
+            },
+            ServiceOfferKind: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+                enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+            },
+            UserMetadata: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    serviceOffers: {
                         type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            serviceOffers: {
-                                type: 'object',
-                                nullable: true,
-                                'x-dictionaryKey': {
-                                    $ref: '#/components/schemas/ServiceOfferKind',
-                                },
-                                additionalProperties: {
-                                    $ref: '#/components/schemas/BillingProviderKind',
-                                },
-                            },
-                            copy: {
-                                type: 'object',
-                                nullable: true,
-                                'x-dictionaryKey': {
-                                    $ref: '#/components/schemas/ServiceOfferKind',
-                                },
-                                additionalProperties: {
-                                    $ref: '#/components/schemas/BillingProviderKind',
-                                },
-                            },
+                        nullable: true,
+                        'x-dictionaryKey': {
+                            $ref: '#/components/schemas/ServiceOfferKind',
+                        },
+                        additionalProperties: {
+                            $ref: '#/components/schemas/BillingProviderKind',
+                        },
+                    },
+                    copy: {
+                        type: 'object',
+                        nullable: true,
+                        'x-dictionaryKey': {
+                            $ref: '#/components/schemas/ServiceOfferKind',
+                        },
+                        additionalProperties: {
+                            $ref: '#/components/schemas/BillingProviderKind',
                         },
                     },
                 },
             },
-        };
+        });
 
-        const resultString = parseSchemas({ json: example, swaggerVersion: 3 });
+        const resultString = parseSchemas({ json });
 
         const expectedString = `export type BillingProviderKind = 'Legacy' | 'Fusebill';
 export type ServiceOfferKind = 'MasteringAndDistribution' | 'Video' | 'Samples' | 'Mastering' | 'Distribution';
@@ -762,52 +739,48 @@ export interface UserMetadata {
 });
 
 it('should return type for a multiple "dictionary" types', async () => {
-    const example = {
-        components: {
-            schemas: {
-                BillingProviderKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': ['Legacy', 'Fusebill'],
-                    enum: ['Legacy', 'Fusebill'],
-                },
-                ServiceOfferKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
-                },
-                UserSubscriptions: {
+    const json = aSwaggerV3Mock({
+        BillingProviderKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Legacy', 'Fusebill'],
+            enum: ['Legacy', 'Fusebill'],
+        },
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+        },
+        UserSubscriptions: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                current: {
                     type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        current: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                $ref: '#/components/schemas/CurrentSubscription',
-                            },
-                        },
-                        next: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                $ref: '#/components/schemas/NextSubscription',
-                            },
-                        },
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
+                    },
+                    additionalProperties: {
+                        $ref: '#/components/schemas/CurrentSubscription',
+                    },
+                },
+                next: {
+                    type: 'object',
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
+                    },
+                    additionalProperties: {
+                        $ref: '#/components/schemas/NextSubscription',
                     },
                 },
             },
         },
-    };
+    });
 
-    const resultString = parseSchemas({ json: example, swaggerVersion: 3 });
+    const resultString = parseSchemas({ json });
 
     const expectedString = `export type BillingProviderKind = 'Legacy' | 'Fusebill';
 export type ServiceOfferKind = 'MasteringAndDistribution' | 'Video' | 'Samples' | 'Mastering' | 'Distribution';
@@ -825,90 +798,86 @@ export interface UserSubscriptions {
 });
 
 it('should return type for a "dictionary" type boolean', async () => {
-    const example = {
-        components: {
-            schemas: {
-                ContentDtoOfCollectionDto: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        data: {
-                            type: 'array',
-                            nullable: true,
-                            items: {
-                                $ref: '#/components/schemas/CollectionDto',
-                            },
-                        },
-                        paging: {
-                            nullable: true,
-                            oneOf: [
-                                {
-                                    $ref: '#/components/schemas/PagingOptionsDto',
-                                },
-                            ],
-                        },
+    const json = aSwaggerV3Mock({
+        ContentDtoOfCollectionDto: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                data: {
+                    type: 'array',
+                    nullable: true,
+                    items: {
+                        $ref: '#/components/schemas/CollectionDto',
                     },
                 },
-                CollectionDto: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        id: {
-                            type: 'string',
-                            format: 'guid',
+                paging: {
+                    nullable: true,
+                    oneOf: [
+                        {
+                            $ref: '#/components/schemas/PagingOptionsDto',
                         },
-                        ownerId: {
-                            type: 'string',
-                            format: 'guid',
-                        },
-                        name: {
-                            type: 'string',
-                            nullable: true,
-                        },
-                        type: {
-                            $ref: '#/components/schemas/CollectionType',
-                        },
-                        creationTime: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                        lastModifiedTime: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                        isSoftDeleted: {
-                            type: 'boolean',
-                        },
-                        collaborators: {
-                            type: 'array',
-                            nullable: true,
-                            items: {
-                                $ref: '#/components/schemas/CollaboratorDto',
-                            },
-                        },
-                        permissions: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/UserOperation',
-                            },
-                            additionalProperties: {
-                                type: 'boolean',
-                            },
-                        },
-                    },
-                },
-                UserOperation: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': ['Read', 'Write'],
-                    enum: ['Read', 'Write'],
+                    ],
                 },
             },
         },
-    };
+        CollectionDto: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                id: {
+                    type: 'string',
+                    format: 'guid',
+                },
+                ownerId: {
+                    type: 'string',
+                    format: 'guid',
+                },
+                name: {
+                    type: 'string',
+                    nullable: true,
+                },
+                type: {
+                    $ref: '#/components/schemas/CollectionType',
+                },
+                creationTime: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+                lastModifiedTime: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+                isSoftDeleted: {
+                    type: 'boolean',
+                },
+                collaborators: {
+                    type: 'array',
+                    nullable: true,
+                    items: {
+                        $ref: '#/components/schemas/CollaboratorDto',
+                    },
+                },
+                permissions: {
+                    type: 'object',
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/UserOperation',
+                    },
+                    additionalProperties: {
+                        type: 'boolean',
+                    },
+                },
+            },
+        },
+        UserOperation: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Read', 'Write'],
+            enum: ['Read', 'Write'],
+        },
+    });
 
-    const resultString = parseSchemas({ json: example, swaggerVersion: 3 });
+    const resultString = parseSchemas({ json });
 
     const expectedString = `export interface ContentDtoOfCollectionDto {
     data?: CollectionDto[];
@@ -935,29 +904,17 @@ export type UserOperation = 'Read' | 'Write';
 
 it('should return overrided enum schema', async () => {
     // What will be fetched from Swagger Json
-    const example = {
-        components: {
-            schemas: {
-                ServiceOfferKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': [
-                        'MasteringAndDistribution',
-                        'Video',
-                        'Samples',
-                        'Mastering',
-                        'Distribution',
-                        'Sessions',
-                    ],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
-                },
-            },
+    const json = aSwaggerV3Mock({
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
         },
-    };
+    });
 
     const resultString = parseSchemas({
-        json: example,
-        swaggerVersion: 3,
+        json,
         // Overrided value "ServiceOfferKind" enum
         overrideSchemas: [
             {
@@ -980,71 +937,64 @@ export type ServiceOfferKind = 'masteringAndDistribution' | 'video' | 'samples' 
 });
 
 it('should return description', async () => {
-    const example = {
-        components: {
-            schemas: {
-                PlanFrequencyIdentifier: {
+    const json = aSwaggerV3Mock({
+        PlanFrequencyIdentifier: {
+            type: 'object',
+            description: 'PlanFrequencyIdentifier description',
+            additionalProperties: false,
+            properties: {
+                code: {
+                    type: 'string',
+                    description: 'The Fusebill plan code.',
+                    nullable: true,
+                },
+                currentQuantity: {
+                    type: 'number',
+                    description: 'The current quantity of the product within the subscription.',
+                    format: 'decimal',
+                },
+                numberOfCredits: {
+                    type: 'integer',
+                    description: 'The number of credits associated to this subscription product.',
+                    format: 'int32',
+                    nullable: true,
+                },
+                frequency: {
+                    description: 'The interval of the plan (monthly/yearly).',
+                    oneOf: [
+                        {
+                            $ref: '#/components/schemas/Interval',
+                        },
+                    ],
+                },
+                hasOverduePayment: {
                     type: 'object',
-                    description: 'PlanFrequencyIdentifier description',
-                    additionalProperties: false,
-                    properties: {
-                        code: {
-                            type: 'string',
-                            description: 'The Fusebill plan code.',
-                            nullable: true,
-                        },
-                        currentQuantity: {
-                            type: 'number',
-                            description: 'The current quantity of the product within the subscription.',
-                            format: 'decimal',
-                        },
-                        numberOfCredits: {
-                            type: 'integer',
-                            description: 'The number of credits associated to this subscription product.',
-                            format: 'int32',
-                            nullable: true,
-                        },
-                        frequency: {
-                            description: 'The interval of the plan (monthly/yearly).',
-                            oneOf: [
-                                {
-                                    $ref: '#/components/schemas/Interval',
-                                },
-                            ],
-                        },
-                        hasOverduePayment: {
-                            type: 'object',
-                            description: 'Says if the user has overdue payments by service offer.',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                type: 'boolean',
-                            },
-                        },
-                        userIds: {
-                            type: 'array',
-                            description: 'The user IDs.',
-                            items: {
-                                type: 'string',
-                                format: 'guid',
-                            },
-                        },
-                        isDefault: {
-                            type: 'boolean',
-                            description: 'Boolean description',
-                        },
+                    description: 'Says if the user has overdue payments by service offer.',
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
                     },
+                    additionalProperties: {
+                        type: 'boolean',
+                    },
+                },
+                userIds: {
+                    type: 'array',
+                    description: 'The user IDs.',
+                    items: {
+                        type: 'string',
+                        format: 'guid',
+                    },
+                },
+                isDefault: {
+                    type: 'boolean',
+                    description: 'Boolean description',
                 },
             },
         },
-    };
-
-    const resultString = parseSchemas({
-        json: example,
-        swaggerVersion: 3,
     });
+
+    const resultString = parseSchemas({ json });
 
     const expectedString = `/**
  * PlanFrequencyIdentifier description 
@@ -1087,30 +1037,25 @@ export interface PlanFrequencyIdentifier {
 });
 
 it('should return CollectionResponseDto', async () => {
-    const example = {
-        definitions: {
-            'CollectionResponseDto[StoredCreditCardDto]': {
-                title: 'CollectionResponse`1',
-                type: 'object',
-                properties: {
-                    data: {
-                        type: 'array',
-                        items: {
-                            $ref: '#/definitions/StoredCreditCardDto',
-                        },
+    const json = aSwaggerV2Mock({
+        'CollectionResponseDto[StoredCreditCardDto]': {
+            title: 'CollectionResponse`1',
+            type: 'object',
+            properties: {
+                data: {
+                    type: 'array',
+                    items: {
+                        $ref: '#/definitions/StoredCreditCardDto',
                     },
-                    paging: {
-                        $ref: '#/definitions/PagingDto',
-                    },
+                },
+                paging: {
+                    $ref: '#/definitions/PagingDto',
                 },
             },
         },
-    };
-
-    const resultString = parseSchemas({
-        json: example,
-        swaggerVersion: 2,
     });
+
+    const resultString = parseSchemas({ json });
 
     const expectedString = `export interface CollectionResponseDto {
     data: StoredCreditCardDto[];


### PR DESCRIPTION
## 📄  Description
Fixed mocks codegen for the Swagger v2 version `Type[AnotherType]` annotation;

## ✅  Checklist
- [x] Contains no duplicate/temporary code
- [x] Contains no sensitive information
- [ ] Error handling added
- [x] Unit tests added

## Related PRs:
- Part 2: https://github.com/LandrAudio/openapi-codegen-typescript/pull/23 (remove `swaggerVersion` prop)
- Part 3: https://github.com/LandrAudio/openapi-codegen-typescript/pull/24 (and test-utils.ts file)
- Part 4: https://github.com/LandrAudio/openapi-codegen-typescript/pull/25 (prettify `.spec` files)

## 🔗  JIRA Issue
https://mixgenius.atlassian.net/browse/CHFE-789
