### PR TITLE
refactor(test): prettify test from part 3 (part 4)

### DIFF
--- a/tests/mockConverter.test.ts
+++ b/tests/mockConverter.test.ts
@@ -589,22 +589,22 @@ it('should properly parse schemas', async () => {
     fs.mkdirSync.mockReturnValue(false);
 
     const json = aSwaggerV3Mock({
-                One: {
-                    type: 'object',
-                    properties: {
-                        name: {
-                            type: 'string',
-                        },
-                    },
+        One: {
+            type: 'object',
+            properties: {
+                name: {
+                    type: 'string',
                 },
-                Two: {
-                    type: 'object',
-                    properties: {
-                        name: {
-                            type: 'number',
-                        },
-                    },
+            },
+        },
+        Two: {
+            type: 'object',
+            properties: {
+                name: {
+                    type: 'number',
                 },
+            },
+        },
     });
 
     const result = parseSchemas({ json });
@@ -630,23 +630,23 @@ export const aTwoAPI = (overrides?: Partial<Two>): Two => {
 
 it('should convert to mocks hole json object', async () => {
     const json = aSwaggerV3Mock({
-                One: {
-                    type: 'object',
-                    properties: {
-                        name: {
-                            type: 'string',
-                        },
-                    },
+        One: {
+            type: 'object',
+            properties: {
+                name: {
+                    type: 'string',
                 },
-                Two: {
-                    type: 'object',
-                    properties: {
-                        name: {
-                            type: 'number',
-                        },
-                    },
+            },
+        },
+        Two: {
+            type: 'object',
+            properties: {
+                name: {
+                    type: 'number',
                 },
-            });
+            },
+        },
+    });
 
     const result = await convertToMocks({
         json,
@@ -679,68 +679,68 @@ export const aTwoAPI = (overrides?: Partial<Two>): Two => {
 
 it('should generate mocks for "InviteAssetsMembersRequestDto" (multiple extends)', async () => {
     const json = aSwaggerV3Mock({
-                MembersEmailDto: {
+        MembersEmailDto: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['members'],
+            properties: {
+                members: {
+                    type: 'array',
+                    items: {
+                        $ref: '#/components/schemas/MemberEmailDto',
+                    },
+                },
+            },
+        },
+        UserRole: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Owner', 'Collaborator', 'Viewer'],
+            enum: ['Owner', 'Collaborator', 'Viewer'],
+        },
+        InviteMembersRequestDto: {
+            allOf: [
+                {
+                    $ref: '#/components/schemas/MembersEmailDto',
+                },
+                {
                     type: 'object',
                     additionalProperties: false,
-                    required: ['members'],
+                    required: ['role'],
                     properties: {
-                        members: {
+                        message: {
+                            type: 'string',
+                            maxLength: 5000,
+                            nullable: true,
+                        },
+                        role: {
+                            $ref: '#/components/schemas/UserRole',
+                        },
+                    },
+                },
+            ],
+        },
+        InviteAssetsMembersRequestDto: {
+            allOf: [
+                {
+                    $ref: '#/components/schemas/InviteMembersRequestDto',
+                },
+                {
+                    type: 'object',
+                    additionalProperties: false,
+                    required: ['assetIds'],
+                    properties: {
+                        assetIds: {
                             type: 'array',
                             items: {
-                                $ref: '#/components/schemas/MemberEmailDto',
+                                type: 'string',
+                                format: 'guid',
                             },
                         },
                     },
                 },
-                UserRole: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': ['Owner', 'Collaborator', 'Viewer'],
-                    enum: ['Owner', 'Collaborator', 'Viewer'],
-                },
-                InviteMembersRequestDto: {
-                    allOf: [
-                        {
-                            $ref: '#/components/schemas/MembersEmailDto',
-                        },
-                        {
-                            type: 'object',
-                            additionalProperties: false,
-                            required: ['role'],
-                            properties: {
-                                message: {
-                                    type: 'string',
-                                    maxLength: 5000,
-                                    nullable: true,
-                                },
-                                role: {
-                                    $ref: '#/components/schemas/UserRole',
-                                },
-                            },
-                        },
-                    ],
-                },
-                InviteAssetsMembersRequestDto: {
-                    allOf: [
-                        {
-                            $ref: '#/components/schemas/InviteMembersRequestDto',
-                        },
-                        {
-                            type: 'object',
-                            additionalProperties: false,
-                            required: ['assetIds'],
-                            properties: {
-                                assetIds: {
-                                    type: 'array',
-                                    items: {
-                                        type: 'string',
-                                        format: 'guid',
-                                    },
-                                },
-                            },
-                        },
-                    ],
-                },
+            ],
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -787,17 +787,17 @@ export const anInviteAssetsMembersRequestDtoAPI = (overrides?: Partial<InviteAss
 
 it('should generate mocks for "MemberEmailDto" (email property)', async () => {
     const json = aSwaggerV3Mock({
-                MemberEmailDto: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        email: {
-                            type: 'string',
-                            format: 'email',
-                            nullable: true,
-                        },
-                    },
+        MemberEmailDto: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                email: {
+                    type: 'string',
+                    format: 'email',
+                    nullable: true,
                 },
+            },
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -825,42 +825,42 @@ export const aMemberEmailDtoAPI = (overrides?: Partial<MemberEmailDto>): MemberE
 
 it('should generate mocks for "Comment" (duration property)', async () => {
     const json = aSwaggerV3Mock({
-                Comment: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        id: {
-                            type: 'string',
-                            format: 'guid',
-                        },
-                        message: {
-                            type: 'string',
-                            nullable: true,
-                        },
-                        userId: {
-                            type: 'string',
-                            format: 'guid',
-                        },
-                        annotationTime: {
-                            type: 'string',
-                            format: 'time-span',
-                            nullable: true,
-                        },
-                        annotationDuration: {
-                            type: 'string',
-                            format: 'time-span',
-                            nullable: true,
-                        },
-                        creationTime: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                        lastModifiedTime: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                    },
+        Comment: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                id: {
+                    type: 'string',
+                    format: 'guid',
                 },
+                message: {
+                    type: 'string',
+                    nullable: true,
+                },
+                userId: {
+                    type: 'string',
+                    format: 'guid',
+                },
+                annotationTime: {
+                    type: 'string',
+                    format: 'time-span',
+                    nullable: true,
+                },
+                annotationDuration: {
+                    type: 'string',
+                    format: 'time-span',
+                    nullable: true,
+                },
+                creationTime: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+                lastModifiedTime: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+            },
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -894,20 +894,20 @@ export const aCommentAPI = (overrides?: Partial<Comment>): Comment => {
 
 it('should generate mocks for array of integers', async () => {
     const json = aSwaggerV3Mock({
-                ArrayOfIntegers: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        invoiceNumbers: {
-                            type: 'array',
-                            nullable: true,
-                            items: {
-                                type: 'integer',
-                                format: 'int64',
-                            },
-                        },
+        ArrayOfIntegers: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                invoiceNumbers: {
+                    type: 'array',
+                    nullable: true,
+                    items: {
+                        type: 'integer',
+                        format: 'int64',
                     },
                 },
+            },
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -934,15 +934,15 @@ export const anArrayOfIntegersAPI = (overrides?: Partial<ArrayOfIntegers>): Arra
 
 it('should generate mocks for a property without a "type"', async () => {
     const json = aSwaggerV3Mock({
-                Notification: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        payload: {
-                            nullable: true,
-                        },
-                    },
+        Notification: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                payload: {
+                    nullable: true,
                 },
+            },
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -969,44 +969,44 @@ export const aNotificationAPI = (overrides?: Partial<Notification>): Notificatio
 
 it('should generate mocks for a enum "dictionary" type', async () => {
     const json = aSwaggerV3Mock({
-                BillingProviderKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': ['Legacy', 'Fusebill'],
-                    enum: ['Legacy', 'Fusebill'],
-                },
-                ServiceOfferKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
-                },
-                UserMetadata: {
+        BillingProviderKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Legacy', 'Fusebill'],
+            enum: ['Legacy', 'Fusebill'],
+        },
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+        },
+        UserMetadata: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                serviceOffers: {
                     type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        serviceOffers: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                $ref: '#/components/schemas/BillingProviderKind',
-                            },
-                        },
-                        copy: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                $ref: '#/components/schemas/BillingProviderKind',
-                            },
-                        },
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
+                    },
+                    additionalProperties: {
+                        $ref: '#/components/schemas/BillingProviderKind',
                     },
                 },
+                copy: {
+                    type: 'object',
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
+                    },
+                    additionalProperties: {
+                        $ref: '#/components/schemas/BillingProviderKind',
+                    },
+                },
+            },
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -1046,63 +1046,63 @@ export const anUserMetadataAPI = (overrides?: Partial<UserMetadata>): UserMetada
 
 it('should generate mocks for an object "dictionary" type', async () => {
     const json = aSwaggerV3Mock({
-                ServiceOfferKind: {
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+        },
+        CurrentSubscription: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                creationDate: {
                     type: 'string',
-                    description: '',
-                    'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+                    format: 'date-time',
                 },
-                CurrentSubscription: {
+                activationDate: {
+                    type: 'string',
+                    format: 'date-time',
+                    nullable: true,
+                },
+            },
+        },
+        NextSubscription: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                startDate: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+            },
+        },
+        UserSubscriptions: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                current: {
                     type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        creationDate: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                        activationDate: {
-                            type: 'string',
-                            format: 'date-time',
-                            nullable: true,
-                        },
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
+                    },
+                    additionalProperties: {
+                        $ref: '#/components/schemas/CurrentSubscription',
                     },
                 },
-                NextSubscription: {
+                next: {
                     type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        startDate: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
+                    },
+                    additionalProperties: {
+                        $ref: '#/components/schemas/NextSubscription',
                     },
                 },
-                UserSubscriptions: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        current: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                $ref: '#/components/schemas/CurrentSubscription',
-                            },
-                        },
-                        next: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                $ref: '#/components/schemas/NextSubscription',
-                            },
-                        },
-                    },
-                },
+            },
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -1157,79 +1157,79 @@ export const anUserSubscriptionsAPI = (overrides?: Partial<UserSubscriptions>): 
 
 it('should generate mocks for a "dictionary" type boolean', async () => {
     const json = aSwaggerV3Mock({
-                ContentDtoOfCollectionDto: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        data: {
-                            type: 'array',
-                            nullable: true,
-                            items: {
-                                $ref: '#/components/schemas/CollectionDto',
-                            },
-                        },
-                        paging: {
-                            nullable: true,
-                            oneOf: [
-                                {
-                                    $ref: '#/components/schemas/PagingOptionsDto',
-                                },
-                            ],
-                        },
+        ContentDtoOfCollectionDto: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                data: {
+                    type: 'array',
+                    nullable: true,
+                    items: {
+                        $ref: '#/components/schemas/CollectionDto',
                     },
                 },
-                CollectionDto: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        id: {
-                            type: 'string',
-                            format: 'guid',
+                paging: {
+                    nullable: true,
+                    oneOf: [
+                        {
+                            $ref: '#/components/schemas/PagingOptionsDto',
                         },
-                        ownerId: {
-                            type: 'string',
-                            format: 'guid',
-                        },
-                        name: {
-                            type: 'string',
-                            nullable: true,
-                        },
-                        creationTime: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                        lastModifiedTime: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                        isSoftDeleted: {
-                            type: 'boolean',
-                        },
-                        collaborators: {
-                            type: 'array',
-                            nullable: true,
-                            items: {
-                                $ref: '#/components/schemas/CollaboratorDto',
-                            },
-                        },
-                        permissions: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/UserOperation',
-                            },
-                            additionalProperties: {
-                                type: 'boolean',
-                            },
-                        },
-                    },
+                    ],
                 },
-                UserOperation: {
+            },
+        },
+        CollectionDto: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                id: {
                     type: 'string',
-                    description: '',
-                    'x-enumNames': ['Read', 'Write'],
-                    enum: ['Read', 'Write'],
+                    format: 'guid',
                 },
+                ownerId: {
+                    type: 'string',
+                    format: 'guid',
+                },
+                name: {
+                    type: 'string',
+                    nullable: true,
+                },
+                creationTime: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+                lastModifiedTime: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+                isSoftDeleted: {
+                    type: 'boolean',
+                },
+                collaborators: {
+                    type: 'array',
+                    nullable: true,
+                    items: {
+                        $ref: '#/components/schemas/CollaboratorDto',
+                    },
+                },
+                permissions: {
+                    type: 'object',
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/UserOperation',
+                    },
+                    additionalProperties: {
+                        type: 'boolean',
+                    },
+                },
+            },
+        },
+        UserOperation: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Read', 'Write'],
+            enum: ['Read', 'Write'],
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -1274,41 +1274,34 @@ export const aCollectionDtoAPI = (overrides?: Partial<CollectionDto>): Collectio
 
 it('should generate overrided mocks for dictionary enum type', async () => {
     const json = aSwaggerV3Mock({
-                UserMetadata: {
+        UserMetadata: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                serviceOffers: {
                     type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        serviceOffers: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                $ref: '#/components/schemas/BillingProviderKind',
-                            },
-                        },
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
+                    },
+                    additionalProperties: {
+                        $ref: '#/components/schemas/BillingProviderKind',
                     },
                 },
-                ServiceOfferKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': [
-                        'MasteringAndDistribution',
-                        'Video',
-                        'Samples',
-                        'Mastering',
-                        'Distribution',
-                        'Sessions',
-                    ],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
-                },
-                BillingProviderKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': ['Legacy', 'Fusebill'],
-                    enum: ['Legacy', 'Fusebill'],
-                },
+            },
+        },
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+        },
+        BillingProviderKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Legacy', 'Fusebill'],
+            enum: ['Legacy', 'Fusebill'],
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -1351,33 +1344,26 @@ export const anUserMetadataAPI = (overrides?: Partial<UserMetadata>): UserMetada
 
 it('should generate overrided mocks for oneOf enum type', async () => {
     const json = aSwaggerV3Mock({
-                CurrentSubscription: {
-                    type: "object",
-                    additionalProperties: false,
-                    properties: {
-                        serviceOffer: {
-                            description: "the service offer of the subscription.",
-                            oneOf: [
-                                {
-                                    $ref: "#/components/schemas/ServiceOfferKind"
-                                }
-                            ]
+        CurrentSubscription: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                serviceOffer: {
+                    description: 'the service offer of the subscription.',
+                    oneOf: [
+                        {
+                            $ref: '#/components/schemas/ServiceOfferKind',
                         },
-                    }
-                },
-                ServiceOfferKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': [
-                        'MasteringAndDistribution',
-                        'Video',
-                        'Samples',
-                        'Mastering',
-                        'Distribution',
-                        'Sessions',
                     ],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
                 },
+            },
+        },
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -1413,28 +1399,21 @@ export const aCurrentSubscriptionAPI = (overrides?: Partial<CurrentSubscription>
 
 it('should generate overrided mocks for $ref enum type', async () => {
     const json = aSwaggerV3Mock({
-                NextSubscription: {
-                    type: "object",
-                    additionalProperties: false,
-                    properties: {
-                        serviceOffer: {
-                            $ref: "#/components/schemas/ServiceOfferKind"
-                        },
-                    }
+        NextSubscription: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                serviceOffer: {
+                    $ref: '#/components/schemas/ServiceOfferKind',
                 },
-                ServiceOfferKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': [
-                        'MasteringAndDistribution',
-                        'Video',
-                        'Samples',
-                        'Mastering',
-                        'Distribution',
-                        'Sessions',
-                    ],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
-                },
+            },
+        },
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -1470,17 +1449,17 @@ export const aNextSubscriptionAPI = (overrides?: Partial<NextSubscription>): Nex
 
 it('should generate mocks for a URI type', async () => {
     const json = aSwaggerV3Mock({
-                DownloadDto: {
-                    type: "object",
-                    additionalProperties: false,
-                    properties: {
-                        url: {
-                            type: 'string',
-                            format: 'uri',
-                            nullable: true,
-                        }
-                    }
+        DownloadDto: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                url: {
+                    type: 'string',
+                    format: 'uri',
+                    nullable: true,
                 },
+            },
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */

--- a/tests/mockConverter.test.ts
+++ b/tests/mockConverter.test.ts
@@ -589,22 +589,22 @@ it('should properly parse schemas', async () => {
     fs.mkdirSync.mockReturnValue(false);
 
     const json = swaggerV3Mock({
-                One: {
-                    type: 'object',
-                    properties: {
-                        name: {
-                            type: 'string',
-                        },
-                    },
+        One: {
+            type: 'object',
+            properties: {
+                name: {
+                    type: 'string',
                 },
-                Two: {
-                    type: 'object',
-                    properties: {
-                        name: {
-                            type: 'number',
-                        },
-                    },
+            },
+        },
+        Two: {
+            type: 'object',
+            properties: {
+                name: {
+                    type: 'number',
                 },
+            },
+        },
     });
 
     const result = parseSchemas({ json });
@@ -630,23 +630,23 @@ export const aTwoAPI = (overrides?: Partial<Two>): Two => {
 
 it('should convert to mocks hole json object', async () => {
     const json = swaggerV3Mock({
-                One: {
-                    type: 'object',
-                    properties: {
-                        name: {
-                            type: 'string',
-                        },
-                    },
+        One: {
+            type: 'object',
+            properties: {
+                name: {
+                    type: 'string',
                 },
-                Two: {
-                    type: 'object',
-                    properties: {
-                        name: {
-                            type: 'number',
-                        },
-                    },
+            },
+        },
+        Two: {
+            type: 'object',
+            properties: {
+                name: {
+                    type: 'number',
                 },
-            });
+            },
+        },
+    });
 
     const result = await convertToMocks({
         json,
@@ -679,68 +679,68 @@ export const aTwoAPI = (overrides?: Partial<Two>): Two => {
 
 it('should generate mocks for "InviteAssetsMembersRequestDto" (multiple extends)', async () => {
     const json = swaggerV3Mock({
-                MembersEmailDto: {
+        MembersEmailDto: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['members'],
+            properties: {
+                members: {
+                    type: 'array',
+                    items: {
+                        $ref: '#/components/schemas/MemberEmailDto',
+                    },
+                },
+            },
+        },
+        UserRole: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Owner', 'Collaborator', 'Viewer'],
+            enum: ['Owner', 'Collaborator', 'Viewer'],
+        },
+        InviteMembersRequestDto: {
+            allOf: [
+                {
+                    $ref: '#/components/schemas/MembersEmailDto',
+                },
+                {
                     type: 'object',
                     additionalProperties: false,
-                    required: ['members'],
+                    required: ['role'],
                     properties: {
-                        members: {
+                        message: {
+                            type: 'string',
+                            maxLength: 5000,
+                            nullable: true,
+                        },
+                        role: {
+                            $ref: '#/components/schemas/UserRole',
+                        },
+                    },
+                },
+            ],
+        },
+        InviteAssetsMembersRequestDto: {
+            allOf: [
+                {
+                    $ref: '#/components/schemas/InviteMembersRequestDto',
+                },
+                {
+                    type: 'object',
+                    additionalProperties: false,
+                    required: ['assetIds'],
+                    properties: {
+                        assetIds: {
                             type: 'array',
                             items: {
-                                $ref: '#/components/schemas/MemberEmailDto',
+                                type: 'string',
+                                format: 'guid',
                             },
                         },
                     },
                 },
-                UserRole: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': ['Owner', 'Collaborator', 'Viewer'],
-                    enum: ['Owner', 'Collaborator', 'Viewer'],
-                },
-                InviteMembersRequestDto: {
-                    allOf: [
-                        {
-                            $ref: '#/components/schemas/MembersEmailDto',
-                        },
-                        {
-                            type: 'object',
-                            additionalProperties: false,
-                            required: ['role'],
-                            properties: {
-                                message: {
-                                    type: 'string',
-                                    maxLength: 5000,
-                                    nullable: true,
-                                },
-                                role: {
-                                    $ref: '#/components/schemas/UserRole',
-                                },
-                            },
-                        },
-                    ],
-                },
-                InviteAssetsMembersRequestDto: {
-                    allOf: [
-                        {
-                            $ref: '#/components/schemas/InviteMembersRequestDto',
-                        },
-                        {
-                            type: 'object',
-                            additionalProperties: false,
-                            required: ['assetIds'],
-                            properties: {
-                                assetIds: {
-                                    type: 'array',
-                                    items: {
-                                        type: 'string',
-                                        format: 'guid',
-                                    },
-                                },
-                            },
-                        },
-                    ],
-                },
+            ],
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -787,17 +787,17 @@ export const anInviteAssetsMembersRequestDtoAPI = (overrides?: Partial<InviteAss
 
 it('should generate mocks for "MemberEmailDto" (email property)', async () => {
     const json = swaggerV3Mock({
-                MemberEmailDto: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        email: {
-                            type: 'string',
-                            format: 'email',
-                            nullable: true,
-                        },
-                    },
+        MemberEmailDto: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                email: {
+                    type: 'string',
+                    format: 'email',
+                    nullable: true,
                 },
+            },
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -825,42 +825,42 @@ export const aMemberEmailDtoAPI = (overrides?: Partial<MemberEmailDto>): MemberE
 
 it('should generate mocks for "Comment" (duration property)', async () => {
     const json = swaggerV3Mock({
-                Comment: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        id: {
-                            type: 'string',
-                            format: 'guid',
-                        },
-                        message: {
-                            type: 'string',
-                            nullable: true,
-                        },
-                        userId: {
-                            type: 'string',
-                            format: 'guid',
-                        },
-                        annotationTime: {
-                            type: 'string',
-                            format: 'time-span',
-                            nullable: true,
-                        },
-                        annotationDuration: {
-                            type: 'string',
-                            format: 'time-span',
-                            nullable: true,
-                        },
-                        creationTime: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                        lastModifiedTime: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                    },
+        Comment: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                id: {
+                    type: 'string',
+                    format: 'guid',
                 },
+                message: {
+                    type: 'string',
+                    nullable: true,
+                },
+                userId: {
+                    type: 'string',
+                    format: 'guid',
+                },
+                annotationTime: {
+                    type: 'string',
+                    format: 'time-span',
+                    nullable: true,
+                },
+                annotationDuration: {
+                    type: 'string',
+                    format: 'time-span',
+                    nullable: true,
+                },
+                creationTime: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+                lastModifiedTime: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+            },
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -894,20 +894,20 @@ export const aCommentAPI = (overrides?: Partial<Comment>): Comment => {
 
 it('should generate mocks for array of integers', async () => {
     const json = swaggerV3Mock({
-                ArrayOfIntegers: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        invoiceNumbers: {
-                            type: 'array',
-                            nullable: true,
-                            items: {
-                                type: 'integer',
-                                format: 'int64',
-                            },
-                        },
+        ArrayOfIntegers: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                invoiceNumbers: {
+                    type: 'array',
+                    nullable: true,
+                    items: {
+                        type: 'integer',
+                        format: 'int64',
                     },
                 },
+            },
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -934,15 +934,15 @@ export const anArrayOfIntegersAPI = (overrides?: Partial<ArrayOfIntegers>): Arra
 
 it('should generate mocks for a property without a "type"', async () => {
     const json = swaggerV3Mock({
-                Notification: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        payload: {
-                            nullable: true,
-                        },
-                    },
+        Notification: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                payload: {
+                    nullable: true,
                 },
+            },
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -969,44 +969,44 @@ export const aNotificationAPI = (overrides?: Partial<Notification>): Notificatio
 
 it('should generate mocks for a enum "dictionary" type', async () => {
     const json = swaggerV3Mock({
-                BillingProviderKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': ['Legacy', 'Fusebill'],
-                    enum: ['Legacy', 'Fusebill'],
-                },
-                ServiceOfferKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
-                },
-                UserMetadata: {
+        BillingProviderKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Legacy', 'Fusebill'],
+            enum: ['Legacy', 'Fusebill'],
+        },
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+        },
+        UserMetadata: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                serviceOffers: {
                     type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        serviceOffers: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                $ref: '#/components/schemas/BillingProviderKind',
-                            },
-                        },
-                        copy: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                $ref: '#/components/schemas/BillingProviderKind',
-                            },
-                        },
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
+                    },
+                    additionalProperties: {
+                        $ref: '#/components/schemas/BillingProviderKind',
                     },
                 },
+                copy: {
+                    type: 'object',
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
+                    },
+                    additionalProperties: {
+                        $ref: '#/components/schemas/BillingProviderKind',
+                    },
+                },
+            },
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -1046,63 +1046,63 @@ export const anUserMetadataAPI = (overrides?: Partial<UserMetadata>): UserMetada
 
 it('should generate mocks for an object "dictionary" type', async () => {
     const json = swaggerV3Mock({
-                ServiceOfferKind: {
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+        },
+        CurrentSubscription: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                creationDate: {
                     type: 'string',
-                    description: '',
-                    'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+                    format: 'date-time',
                 },
-                CurrentSubscription: {
+                activationDate: {
+                    type: 'string',
+                    format: 'date-time',
+                    nullable: true,
+                },
+            },
+        },
+        NextSubscription: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                startDate: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+            },
+        },
+        UserSubscriptions: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                current: {
                     type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        creationDate: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                        activationDate: {
-                            type: 'string',
-                            format: 'date-time',
-                            nullable: true,
-                        },
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
+                    },
+                    additionalProperties: {
+                        $ref: '#/components/schemas/CurrentSubscription',
                     },
                 },
-                NextSubscription: {
+                next: {
                     type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        startDate: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
+                    },
+                    additionalProperties: {
+                        $ref: '#/components/schemas/NextSubscription',
                     },
                 },
-                UserSubscriptions: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        current: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                $ref: '#/components/schemas/CurrentSubscription',
-                            },
-                        },
-                        next: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                $ref: '#/components/schemas/NextSubscription',
-                            },
-                        },
-                    },
-                },
+            },
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -1157,79 +1157,79 @@ export const anUserSubscriptionsAPI = (overrides?: Partial<UserSubscriptions>): 
 
 it('should generate mocks for a "dictionary" type boolean', async () => {
     const json = swaggerV3Mock({
-                ContentDtoOfCollectionDto: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        data: {
-                            type: 'array',
-                            nullable: true,
-                            items: {
-                                $ref: '#/components/schemas/CollectionDto',
-                            },
-                        },
-                        paging: {
-                            nullable: true,
-                            oneOf: [
-                                {
-                                    $ref: '#/components/schemas/PagingOptionsDto',
-                                },
-                            ],
-                        },
+        ContentDtoOfCollectionDto: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                data: {
+                    type: 'array',
+                    nullable: true,
+                    items: {
+                        $ref: '#/components/schemas/CollectionDto',
                     },
                 },
-                CollectionDto: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        id: {
-                            type: 'string',
-                            format: 'guid',
+                paging: {
+                    nullable: true,
+                    oneOf: [
+                        {
+                            $ref: '#/components/schemas/PagingOptionsDto',
                         },
-                        ownerId: {
-                            type: 'string',
-                            format: 'guid',
-                        },
-                        name: {
-                            type: 'string',
-                            nullable: true,
-                        },
-                        creationTime: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                        lastModifiedTime: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                        isSoftDeleted: {
-                            type: 'boolean',
-                        },
-                        collaborators: {
-                            type: 'array',
-                            nullable: true,
-                            items: {
-                                $ref: '#/components/schemas/CollaboratorDto',
-                            },
-                        },
-                        permissions: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/UserOperation',
-                            },
-                            additionalProperties: {
-                                type: 'boolean',
-                            },
-                        },
-                    },
+                    ],
                 },
-                UserOperation: {
+            },
+        },
+        CollectionDto: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                id: {
                     type: 'string',
-                    description: '',
-                    'x-enumNames': ['Read', 'Write'],
-                    enum: ['Read', 'Write'],
+                    format: 'guid',
                 },
+                ownerId: {
+                    type: 'string',
+                    format: 'guid',
+                },
+                name: {
+                    type: 'string',
+                    nullable: true,
+                },
+                creationTime: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+                lastModifiedTime: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+                isSoftDeleted: {
+                    type: 'boolean',
+                },
+                collaborators: {
+                    type: 'array',
+                    nullable: true,
+                    items: {
+                        $ref: '#/components/schemas/CollaboratorDto',
+                    },
+                },
+                permissions: {
+                    type: 'object',
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/UserOperation',
+                    },
+                    additionalProperties: {
+                        type: 'boolean',
+                    },
+                },
+            },
+        },
+        UserOperation: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Read', 'Write'],
+            enum: ['Read', 'Write'],
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -1274,41 +1274,34 @@ export const aCollectionDtoAPI = (overrides?: Partial<CollectionDto>): Collectio
 
 it('should generate overrided mocks for dictionary enum type', async () => {
     const json = swaggerV3Mock({
-                UserMetadata: {
+        UserMetadata: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                serviceOffers: {
                     type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        serviceOffers: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                $ref: '#/components/schemas/BillingProviderKind',
-                            },
-                        },
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
+                    },
+                    additionalProperties: {
+                        $ref: '#/components/schemas/BillingProviderKind',
                     },
                 },
-                ServiceOfferKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': [
-                        'MasteringAndDistribution',
-                        'Video',
-                        'Samples',
-                        'Mastering',
-                        'Distribution',
-                        'Sessions',
-                    ],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
-                },
-                BillingProviderKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': ['Legacy', 'Fusebill'],
-                    enum: ['Legacy', 'Fusebill'],
-                },
+            },
+        },
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+        },
+        BillingProviderKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Legacy', 'Fusebill'],
+            enum: ['Legacy', 'Fusebill'],
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -1351,33 +1344,26 @@ export const anUserMetadataAPI = (overrides?: Partial<UserMetadata>): UserMetada
 
 it('should generate overrided mocks for oneOf enum type', async () => {
     const json = swaggerV3Mock({
-                CurrentSubscription: {
-                    type: "object",
-                    additionalProperties: false,
-                    properties: {
-                        serviceOffer: {
-                            description: "the service offer of the subscription.",
-                            oneOf: [
-                                {
-                                    $ref: "#/components/schemas/ServiceOfferKind"
-                                }
-                            ]
+        CurrentSubscription: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                serviceOffer: {
+                    description: 'the service offer of the subscription.',
+                    oneOf: [
+                        {
+                            $ref: '#/components/schemas/ServiceOfferKind',
                         },
-                    }
-                },
-                ServiceOfferKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': [
-                        'MasteringAndDistribution',
-                        'Video',
-                        'Samples',
-                        'Mastering',
-                        'Distribution',
-                        'Sessions',
                     ],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
                 },
+            },
+        },
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -1413,28 +1399,21 @@ export const aCurrentSubscriptionAPI = (overrides?: Partial<CurrentSubscription>
 
 it('should generate overrided mocks for $ref enum type', async () => {
     const json = swaggerV3Mock({
-                NextSubscription: {
-                    type: "object",
-                    additionalProperties: false,
-                    properties: {
-                        serviceOffer: {
-                            $ref: "#/components/schemas/ServiceOfferKind"
-                        },
-                    }
+        NextSubscription: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                serviceOffer: {
+                    $ref: '#/components/schemas/ServiceOfferKind',
                 },
-                ServiceOfferKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': [
-                        'MasteringAndDistribution',
-                        'Video',
-                        'Samples',
-                        'Mastering',
-                        'Distribution',
-                        'Sessions',
-                    ],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
-                },
+            },
+        },
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
@@ -1470,17 +1449,17 @@ export const aNextSubscriptionAPI = (overrides?: Partial<NextSubscription>): Nex
 
 it('should generate mocks for a URI type', async () => {
     const json = swaggerV3Mock({
-                DownloadDto: {
-                    type: "object",
-                    additionalProperties: false,
-                    properties: {
-                        url: {
-                            type: 'string',
-                            format: 'uri',
-                            nullable: true,
-                        }
-                    }
+        DownloadDto: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                url: {
+                    type: 'string',
+                    format: 'uri',
+                    nullable: true,
                 },
+            },
+        },
     });
 
     const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */

--- a/tests/shared.test.ts
+++ b/tests/shared.test.ts
@@ -46,22 +46,22 @@ describe('TS types generation', () => {
 
     it('should parse v2 schemas', async () => {
         const json = swaggerV2Mock({
-                One: {
-                    type: 'object',
-                    properties: {
-                        name: {
-                            type: 'string',
-                        },
+            One: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'string',
                     },
                 },
-                Two: {
-                    type: 'object',
-                    properties: {
-                        name: {
-                            type: 'number',
-                        },
+            },
+            Two: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'number',
                     },
                 },
+            },
         });
 
         const parsedData = getSchemas({ json });
@@ -89,22 +89,22 @@ describe('TS types generation', () => {
 
     it('should parse v3 schemas', async () => {
         const json = swaggerV3Mock({
-                    One: {
-                        type: 'object',
-                        properties: {
-                            name: {
-                                type: 'string',
-                            },
-                        },
+            One: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'string',
                     },
-                    Two: {
-                        type: 'object',
-                        properties: {
-                            name: {
-                                type: 'number',
-                            },
-                        },
+                },
+            },
+            Two: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'number',
                     },
+                },
+            },
         });
 
         const parsedData = getSchemas({ json });
@@ -132,22 +132,22 @@ describe('TS types generation', () => {
 
     it('should parse v3 schemas by default', async () => {
         const json = swaggerV3Mock({
-                    One: {
-                        type: 'object',
-                        properties: {
-                            name: {
-                                type: 'string',
-                            },
-                        },
+            One: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'string',
                     },
-                    Two: {
-                        type: 'object',
-                        properties: {
-                            name: {
-                                type: 'number',
-                            },
-                        },
+                },
+            },
+            Two: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'number',
                     },
+                },
+            },
         });
 
         const parsedData = getSchemas({ json });

--- a/tests/shared.test.ts
+++ b/tests/shared.test.ts
@@ -46,22 +46,22 @@ describe('TS types generation', () => {
 
     it('should parse v2 schemas', async () => {
         const json = aSwaggerV2Mock({
-                One: {
-                    type: 'object',
-                    properties: {
-                        name: {
-                            type: 'string',
-                        },
+            One: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'string',
                     },
                 },
-                Two: {
-                    type: 'object',
-                    properties: {
-                        name: {
-                            type: 'number',
-                        },
+            },
+            Two: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'number',
                     },
                 },
+            },
         });
 
         const parsedData = getSchemas({ json });
@@ -89,22 +89,22 @@ describe('TS types generation', () => {
 
     it('should parse v3 schemas', async () => {
         const json = aSwaggerV3Mock({
-                    One: {
-                        type: 'object',
-                        properties: {
-                            name: {
-                                type: 'string',
-                            },
-                        },
+            One: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'string',
                     },
-                    Two: {
-                        type: 'object',
-                        properties: {
-                            name: {
-                                type: 'number',
-                            },
-                        },
+                },
+            },
+            Two: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'number',
                     },
+                },
+            },
         });
 
         const parsedData = getSchemas({ json });
@@ -132,22 +132,22 @@ describe('TS types generation', () => {
 
     it('should parse v3 schemas by default', async () => {
         const json = aSwaggerV3Mock({
-                    One: {
-                        type: 'object',
-                        properties: {
-                            name: {
-                                type: 'string',
-                            },
-                        },
+            One: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'string',
                     },
-                    Two: {
-                        type: 'object',
-                        properties: {
-                            name: {
-                                type: 'number',
-                            },
-                        },
+                },
+            },
+            Two: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'number',
                     },
+                },
+            },
         });
 
         const parsedData = getSchemas({ json });

--- a/tests/typeConverter.test.ts
+++ b/tests/typeConverter.test.ts
@@ -453,89 +453,89 @@ export interface AssetDto {
 
     it('should properly combine in one file', async () => {
         const json = aSwaggerV3Mock({
-                    AssetDto: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            id: {
-                                type: 'string',
-                                format: 'guid',
-                            },
-                            name: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                            type: {
-                                $ref: '#/components/schemas/AssetType',
-                            },
-                            files: {
-                                type: 'array',
-                                nullable: true,
-                                items: {
-                                    $ref: '#/components/schemas/AssetFileDto',
-                                },
-                            },
+            AssetDto: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    id: {
+                        type: 'string',
+                        format: 'guid',
+                    },
+                    name: {
+                        type: 'string',
+                        nullable: true,
+                    },
+                    type: {
+                        $ref: '#/components/schemas/AssetType',
+                    },
+                    files: {
+                        type: 'array',
+                        nullable: true,
+                        items: {
+                            $ref: '#/components/schemas/AssetFileDto',
                         },
                     },
-                    AssetType: {
+                },
+            },
+            AssetType: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Audio', 'Video', 'Image'],
+                enum: ['Audio', 'Video', 'Image'],
+            },
+            AssetFileDto: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    state: {
+                        $ref: '#/components/schemas/FileState',
+                    },
+                    kind: {
+                        $ref: '#/components/schemas/FileKind',
+                    },
+                    creationTime: {
                         type: 'string',
-                        description: '',
-                        'x-enumNames': ['Audio', 'Video', 'Image'],
-                        enum: ['Audio', 'Video', 'Image'],
+                        format: 'date-time',
                     },
-                    AssetFileDto: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            state: {
-                                $ref: '#/components/schemas/FileState',
-                            },
-                            kind: {
-                                $ref: '#/components/schemas/FileKind',
-                            },
-                            creationTime: {
-                                type: 'string',
-                                format: 'date-time',
-                            },
-                            contentType: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                            hash: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                            location: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                            sizeBytes: {
-                                type: 'integer',
-                                format: 'int64',
-                            },
-                            duration: {
-                                type: 'number',
-                                format: 'double',
-                                nullable: true,
-                            },
-                            url: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                        },
-                    },
-                    FileState: {
+                    contentType: {
                         type: 'string',
-                        description: '',
-                        'x-enumNames': ['Created', 'Uploading', 'Processing', 'Failed', 'Available', 'Deleted'],
-                        enum: ['Created', 'Uploading', 'Processing', 'Failed', 'Available', 'Deleted'],
+                        nullable: true,
                     },
-                    FileKind: {
+                    hash: {
                         type: 'string',
-                        description: '',
-                        'x-enumNames': ['Original', 'Stream', 'Waveform'],
-                        enum: ['Original', 'Stream', 'Waveform'],
+                        nullable: true,
                     },
+                    location: {
+                        type: 'string',
+                        nullable: true,
+                    },
+                    sizeBytes: {
+                        type: 'integer',
+                        format: 'int64',
+                    },
+                    duration: {
+                        type: 'number',
+                        format: 'double',
+                        nullable: true,
+                    },
+                    url: {
+                        type: 'string',
+                        nullable: true,
+                    },
+                },
+            },
+            FileState: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Created', 'Uploading', 'Processing', 'Failed', 'Available', 'Deleted'],
+                enum: ['Created', 'Uploading', 'Processing', 'Failed', 'Available', 'Deleted'],
+            },
+            FileKind: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Original', 'Stream', 'Waveform'],
+                enum: ['Original', 'Stream', 'Waveform'],
+            },
         });
 
         const resultString = parseSchemas({ json });
@@ -567,11 +567,11 @@ export type FileKind = 'Original' | 'Stream' | 'Waveform';
 
     it('should return TODO text if data type is wrong (catch block)', async () => {
         const json = aSwaggerV3Mock({
-                    FileState: {
-                        type: 'string',
-                        description: '',
-                        $ref: { wrongData: 'wrongData' },
-                    },
+            FileState: {
+                type: 'string',
+                description: '',
+                $ref: { wrongData: 'wrongData' },
+            },
         });
 
         const resultString = parseSchemas({ json });
@@ -583,33 +583,33 @@ export type FileKind = 'Original' | 'Stream' | 'Waveform';
 
     it('should return TODO text if type was not converted', async () => {
         const json = aSwaggerV3Mock({
-                    AssetDto: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            id: {
-                                type: 'string',
-                                format: 'guid',
-                            },
-                            name: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                        },
+            AssetDto: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    id: {
+                        type: 'string',
+                        format: 'guid',
                     },
-                    WrongData: {
-                        type: 'foo',
+                    name: {
+                        type: 'string',
+                        nullable: true,
                     },
-                    AssetFileDto: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            creationTime: {
-                                type: 'string',
-                                format: 'date-time',
-                            },
-                        },
+                },
+            },
+            WrongData: {
+                type: 'foo',
+            },
+            AssetFileDto: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    creationTime: {
+                        type: 'string',
+                        format: 'date-time',
                     },
+                },
+            },
         });
 
         const resultString = parseSchemas({ json });
@@ -629,20 +629,20 @@ export interface AssetFileDto {
 
     it('should return correct type for array of integers', async () => {
         const json = aSwaggerV3Mock({
-                    ArrayOfIntegers: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            invoiceNumbers: {
-                                type: 'array',
-                                nullable: true,
-                                items: {
-                                    type: 'integer',
-                                    format: 'int64',
-                                },
-                            },
+            ArrayOfIntegers: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    invoiceNumbers: {
+                        type: 'array',
+                        nullable: true,
+                        items: {
+                            type: 'integer',
+                            format: 'int64',
                         },
                     },
+                },
+            },
         });
 
         const resultString = parseSchemas({ json });
@@ -657,15 +657,15 @@ export interface AssetFileDto {
 
     it('should return "any" type for property without a type', async () => {
         const json = aSwaggerV3Mock({
-                    Notification: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            payload: {
-                                nullable: true,
-                            },
-                        },
+            Notification: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    payload: {
+                        nullable: true,
                     },
+                },
+            },
         });
 
         const resultString = parseSchemas({ json });
@@ -680,44 +680,44 @@ export interface AssetFileDto {
 
     it('should return type for a "dictionary"', async () => {
         const json = aSwaggerV3Mock({
-                    BillingProviderKind: {
-                        type: 'string',
-                        description: '',
-                        'x-enumNames': ['Legacy', 'Fusebill'],
-                        enum: ['Legacy', 'Fusebill'],
-                    },
-                    ServiceOfferKind: {
-                        type: 'string',
-                        description: '',
-                        'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
-                        enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
-                    },
-                    UserMetadata: {
+            BillingProviderKind: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Legacy', 'Fusebill'],
+                enum: ['Legacy', 'Fusebill'],
+            },
+            ServiceOfferKind: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+                enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+            },
+            UserMetadata: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    serviceOffers: {
                         type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            serviceOffers: {
-                                type: 'object',
-                                nullable: true,
-                                'x-dictionaryKey': {
-                                    $ref: '#/components/schemas/ServiceOfferKind',
-                                },
-                                additionalProperties: {
-                                    $ref: '#/components/schemas/BillingProviderKind',
-                                },
-                            },
-                            copy: {
-                                type: 'object',
-                                nullable: true,
-                                'x-dictionaryKey': {
-                                    $ref: '#/components/schemas/ServiceOfferKind',
-                                },
-                                additionalProperties: {
-                                    $ref: '#/components/schemas/BillingProviderKind',
-                                },
-                            },
+                        nullable: true,
+                        'x-dictionaryKey': {
+                            $ref: '#/components/schemas/ServiceOfferKind',
+                        },
+                        additionalProperties: {
+                            $ref: '#/components/schemas/BillingProviderKind',
                         },
                     },
+                    copy: {
+                        type: 'object',
+                        nullable: true,
+                        'x-dictionaryKey': {
+                            $ref: '#/components/schemas/ServiceOfferKind',
+                        },
+                        additionalProperties: {
+                            $ref: '#/components/schemas/BillingProviderKind',
+                        },
+                    },
+                },
+            },
         });
 
         const resultString = parseSchemas({ json });
@@ -740,44 +740,44 @@ export interface UserMetadata {
 
 it('should return type for a multiple "dictionary" types', async () => {
     const json = aSwaggerV3Mock({
-                BillingProviderKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': ['Legacy', 'Fusebill'],
-                    enum: ['Legacy', 'Fusebill'],
-                },
-                ServiceOfferKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
-                },
-                UserSubscriptions: {
+        BillingProviderKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Legacy', 'Fusebill'],
+            enum: ['Legacy', 'Fusebill'],
+        },
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+        },
+        UserSubscriptions: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                current: {
                     type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        current: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                $ref: '#/components/schemas/CurrentSubscription',
-                            },
-                        },
-                        next: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                $ref: '#/components/schemas/NextSubscription',
-                            },
-                        },
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
+                    },
+                    additionalProperties: {
+                        $ref: '#/components/schemas/CurrentSubscription',
                     },
                 },
+                next: {
+                    type: 'object',
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
+                    },
+                    additionalProperties: {
+                        $ref: '#/components/schemas/NextSubscription',
+                    },
+                },
+            },
+        },
     });
 
     const resultString = parseSchemas({ json });
@@ -799,82 +799,82 @@ export interface UserSubscriptions {
 
 it('should return type for a "dictionary" type boolean', async () => {
     const json = aSwaggerV3Mock({
-                ContentDtoOfCollectionDto: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        data: {
-                            type: 'array',
-                            nullable: true,
-                            items: {
-                                $ref: '#/components/schemas/CollectionDto',
-                            },
-                        },
-                        paging: {
-                            nullable: true,
-                            oneOf: [
-                                {
-                                    $ref: '#/components/schemas/PagingOptionsDto',
-                                },
-                            ],
-                        },
+        ContentDtoOfCollectionDto: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                data: {
+                    type: 'array',
+                    nullable: true,
+                    items: {
+                        $ref: '#/components/schemas/CollectionDto',
                     },
                 },
-                CollectionDto: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        id: {
-                            type: 'string',
-                            format: 'guid',
+                paging: {
+                    nullable: true,
+                    oneOf: [
+                        {
+                            $ref: '#/components/schemas/PagingOptionsDto',
                         },
-                        ownerId: {
-                            type: 'string',
-                            format: 'guid',
-                        },
-                        name: {
-                            type: 'string',
-                            nullable: true,
-                        },
-                        type: {
-                            $ref: '#/components/schemas/CollectionType',
-                        },
-                        creationTime: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                        lastModifiedTime: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                        isSoftDeleted: {
-                            type: 'boolean',
-                        },
-                        collaborators: {
-                            type: 'array',
-                            nullable: true,
-                            items: {
-                                $ref: '#/components/schemas/CollaboratorDto',
-                            },
-                        },
-                        permissions: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/UserOperation',
-                            },
-                            additionalProperties: {
-                                type: 'boolean',
-                            },
-                        },
-                    },
+                    ],
                 },
-                UserOperation: {
+            },
+        },
+        CollectionDto: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                id: {
                     type: 'string',
-                    description: '',
-                    'x-enumNames': ['Read', 'Write'],
-                    enum: ['Read', 'Write'],
+                    format: 'guid',
                 },
+                ownerId: {
+                    type: 'string',
+                    format: 'guid',
+                },
+                name: {
+                    type: 'string',
+                    nullable: true,
+                },
+                type: {
+                    $ref: '#/components/schemas/CollectionType',
+                },
+                creationTime: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+                lastModifiedTime: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+                isSoftDeleted: {
+                    type: 'boolean',
+                },
+                collaborators: {
+                    type: 'array',
+                    nullable: true,
+                    items: {
+                        $ref: '#/components/schemas/CollaboratorDto',
+                    },
+                },
+                permissions: {
+                    type: 'object',
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/UserOperation',
+                    },
+                    additionalProperties: {
+                        type: 'boolean',
+                    },
+                },
+            },
+        },
+        UserOperation: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Read', 'Write'],
+            enum: ['Read', 'Write'],
+        },
     });
 
     const resultString = parseSchemas({ json });
@@ -905,19 +905,12 @@ export type UserOperation = 'Read' | 'Write';
 it('should return overrided enum schema', async () => {
     // What will be fetched from Swagger Json
     const json = aSwaggerV3Mock({
-                ServiceOfferKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': [
-                        'MasteringAndDistribution',
-                        'Video',
-                        'Samples',
-                        'Mastering',
-                        'Distribution',
-                        'Sessions',
-                    ],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
-                },
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+        },
     });
 
     const resultString = parseSchemas({
@@ -945,60 +938,60 @@ export type ServiceOfferKind = 'masteringAndDistribution' | 'video' | 'samples' 
 
 it('should return description', async () => {
     const json = aSwaggerV3Mock({
-                PlanFrequencyIdentifier: {
+        PlanFrequencyIdentifier: {
+            type: 'object',
+            description: 'PlanFrequencyIdentifier description',
+            additionalProperties: false,
+            properties: {
+                code: {
+                    type: 'string',
+                    description: 'The Fusebill plan code.',
+                    nullable: true,
+                },
+                currentQuantity: {
+                    type: 'number',
+                    description: 'The current quantity of the product within the subscription.',
+                    format: 'decimal',
+                },
+                numberOfCredits: {
+                    type: 'integer',
+                    description: 'The number of credits associated to this subscription product.',
+                    format: 'int32',
+                    nullable: true,
+                },
+                frequency: {
+                    description: 'The interval of the plan (monthly/yearly).',
+                    oneOf: [
+                        {
+                            $ref: '#/components/schemas/Interval',
+                        },
+                    ],
+                },
+                hasOverduePayment: {
                     type: 'object',
-                    description: 'PlanFrequencyIdentifier description',
-                    additionalProperties: false,
-                    properties: {
-                        code: {
-                            type: 'string',
-                            description: 'The Fusebill plan code.',
-                            nullable: true,
-                        },
-                        currentQuantity: {
-                            type: 'number',
-                            description: 'The current quantity of the product within the subscription.',
-                            format: 'decimal',
-                        },
-                        numberOfCredits: {
-                            type: 'integer',
-                            description: 'The number of credits associated to this subscription product.',
-                            format: 'int32',
-                            nullable: true,
-                        },
-                        frequency: {
-                            description: 'The interval of the plan (monthly/yearly).',
-                            oneOf: [
-                                {
-                                    $ref: '#/components/schemas/Interval',
-                                },
-                            ],
-                        },
-                        hasOverduePayment: {
-                            type: 'object',
-                            description: 'Says if the user has overdue payments by service offer.',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                type: 'boolean',
-                            },
-                        },
-                        userIds: {
-                            type: 'array',
-                            description: 'The user IDs.',
-                            items: {
-                                type: 'string',
-                                format: 'guid',
-                            },
-                        },
-                        isDefault: {
-                            type: 'boolean',
-                            description: 'Boolean description',
-                        },
+                    description: 'Says if the user has overdue payments by service offer.',
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
+                    },
+                    additionalProperties: {
+                        type: 'boolean',
                     },
                 },
+                userIds: {
+                    type: 'array',
+                    description: 'The user IDs.',
+                    items: {
+                        type: 'string',
+                        format: 'guid',
+                    },
+                },
+                isDefault: {
+                    type: 'boolean',
+                    description: 'Boolean description',
+                },
+            },
+        },
     });
 
     const resultString = parseSchemas({ json });
@@ -1045,21 +1038,21 @@ export interface PlanFrequencyIdentifier {
 
 it('should return CollectionResponseDto', async () => {
     const json = aSwaggerV2Mock({
-            'CollectionResponseDto[StoredCreditCardDto]': {
-                title: 'CollectionResponse`1',
-                type: 'object',
-                properties: {
-                    data: {
-                        type: 'array',
-                        items: {
-                            $ref: '#/definitions/StoredCreditCardDto',
-                        },
-                    },
-                    paging: {
-                        $ref: '#/definitions/PagingDto',
+        'CollectionResponseDto[StoredCreditCardDto]': {
+            title: 'CollectionResponse`1',
+            type: 'object',
+            properties: {
+                data: {
+                    type: 'array',
+                    items: {
+                        $ref: '#/definitions/StoredCreditCardDto',
                     },
                 },
+                paging: {
+                    $ref: '#/definitions/PagingDto',
+                },
             },
+        },
     });
 
     const resultString = parseSchemas({ json });

--- a/tests/typeConverter.test.ts
+++ b/tests/typeConverter.test.ts
@@ -453,89 +453,89 @@ export interface AssetDto {
 
     it('should properly combine in one file', async () => {
         const json = swaggerV3Mock({
-                    AssetDto: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            id: {
-                                type: 'string',
-                                format: 'guid',
-                            },
-                            name: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                            type: {
-                                $ref: '#/components/schemas/AssetType',
-                            },
-                            files: {
-                                type: 'array',
-                                nullable: true,
-                                items: {
-                                    $ref: '#/components/schemas/AssetFileDto',
-                                },
-                            },
+            AssetDto: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    id: {
+                        type: 'string',
+                        format: 'guid',
+                    },
+                    name: {
+                        type: 'string',
+                        nullable: true,
+                    },
+                    type: {
+                        $ref: '#/components/schemas/AssetType',
+                    },
+                    files: {
+                        type: 'array',
+                        nullable: true,
+                        items: {
+                            $ref: '#/components/schemas/AssetFileDto',
                         },
                     },
-                    AssetType: {
+                },
+            },
+            AssetType: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Audio', 'Video', 'Image'],
+                enum: ['Audio', 'Video', 'Image'],
+            },
+            AssetFileDto: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    state: {
+                        $ref: '#/components/schemas/FileState',
+                    },
+                    kind: {
+                        $ref: '#/components/schemas/FileKind',
+                    },
+                    creationTime: {
                         type: 'string',
-                        description: '',
-                        'x-enumNames': ['Audio', 'Video', 'Image'],
-                        enum: ['Audio', 'Video', 'Image'],
+                        format: 'date-time',
                     },
-                    AssetFileDto: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            state: {
-                                $ref: '#/components/schemas/FileState',
-                            },
-                            kind: {
-                                $ref: '#/components/schemas/FileKind',
-                            },
-                            creationTime: {
-                                type: 'string',
-                                format: 'date-time',
-                            },
-                            contentType: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                            hash: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                            location: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                            sizeBytes: {
-                                type: 'integer',
-                                format: 'int64',
-                            },
-                            duration: {
-                                type: 'number',
-                                format: 'double',
-                                nullable: true,
-                            },
-                            url: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                        },
-                    },
-                    FileState: {
+                    contentType: {
                         type: 'string',
-                        description: '',
-                        'x-enumNames': ['Created', 'Uploading', 'Processing', 'Failed', 'Available', 'Deleted'],
-                        enum: ['Created', 'Uploading', 'Processing', 'Failed', 'Available', 'Deleted'],
+                        nullable: true,
                     },
-                    FileKind: {
+                    hash: {
                         type: 'string',
-                        description: '',
-                        'x-enumNames': ['Original', 'Stream', 'Waveform'],
-                        enum: ['Original', 'Stream', 'Waveform'],
+                        nullable: true,
                     },
+                    location: {
+                        type: 'string',
+                        nullable: true,
+                    },
+                    sizeBytes: {
+                        type: 'integer',
+                        format: 'int64',
+                    },
+                    duration: {
+                        type: 'number',
+                        format: 'double',
+                        nullable: true,
+                    },
+                    url: {
+                        type: 'string',
+                        nullable: true,
+                    },
+                },
+            },
+            FileState: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Created', 'Uploading', 'Processing', 'Failed', 'Available', 'Deleted'],
+                enum: ['Created', 'Uploading', 'Processing', 'Failed', 'Available', 'Deleted'],
+            },
+            FileKind: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Original', 'Stream', 'Waveform'],
+                enum: ['Original', 'Stream', 'Waveform'],
+            },
         });
 
         const resultString = parseSchemas({ json });
@@ -567,11 +567,11 @@ export type FileKind = 'Original' | 'Stream' | 'Waveform';
 
     it('should return TODO text if data type is wrong (catch block)', async () => {
         const json = swaggerV3Mock({
-                    FileState: {
-                        type: 'string',
-                        description: '',
-                        $ref: { wrongData: 'wrongData' },
-                    },
+            FileState: {
+                type: 'string',
+                description: '',
+                $ref: { wrongData: 'wrongData' },
+            },
         });
 
         const resultString = parseSchemas({ json });
@@ -583,33 +583,33 @@ export type FileKind = 'Original' | 'Stream' | 'Waveform';
 
     it('should return TODO text if type was not converted', async () => {
         const json = swaggerV3Mock({
-                    AssetDto: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            id: {
-                                type: 'string',
-                                format: 'guid',
-                            },
-                            name: {
-                                type: 'string',
-                                nullable: true,
-                            },
-                        },
+            AssetDto: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    id: {
+                        type: 'string',
+                        format: 'guid',
                     },
-                    WrongData: {
-                        type: 'foo',
+                    name: {
+                        type: 'string',
+                        nullable: true,
                     },
-                    AssetFileDto: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            creationTime: {
-                                type: 'string',
-                                format: 'date-time',
-                            },
-                        },
+                },
+            },
+            WrongData: {
+                type: 'foo',
+            },
+            AssetFileDto: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    creationTime: {
+                        type: 'string',
+                        format: 'date-time',
                     },
+                },
+            },
         });
 
         const resultString = parseSchemas({ json });
@@ -629,20 +629,20 @@ export interface AssetFileDto {
 
     it('should return correct type for array of integers', async () => {
         const json = swaggerV3Mock({
-                    ArrayOfIntegers: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            invoiceNumbers: {
-                                type: 'array',
-                                nullable: true,
-                                items: {
-                                    type: 'integer',
-                                    format: 'int64',
-                                },
-                            },
+            ArrayOfIntegers: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    invoiceNumbers: {
+                        type: 'array',
+                        nullable: true,
+                        items: {
+                            type: 'integer',
+                            format: 'int64',
                         },
                     },
+                },
+            },
         });
 
         const resultString = parseSchemas({ json });
@@ -657,15 +657,15 @@ export interface AssetFileDto {
 
     it('should return "any" type for property without a type', async () => {
         const json = swaggerV3Mock({
-                    Notification: {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            payload: {
-                                nullable: true,
-                            },
-                        },
+            Notification: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    payload: {
+                        nullable: true,
                     },
+                },
+            },
         });
 
         const resultString = parseSchemas({ json });
@@ -680,44 +680,44 @@ export interface AssetFileDto {
 
     it('should return type for a "dictionary"', async () => {
         const json = swaggerV3Mock({
-                    BillingProviderKind: {
-                        type: 'string',
-                        description: '',
-                        'x-enumNames': ['Legacy', 'Fusebill'],
-                        enum: ['Legacy', 'Fusebill'],
-                    },
-                    ServiceOfferKind: {
-                        type: 'string',
-                        description: '',
-                        'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
-                        enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
-                    },
-                    UserMetadata: {
+            BillingProviderKind: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Legacy', 'Fusebill'],
+                enum: ['Legacy', 'Fusebill'],
+            },
+            ServiceOfferKind: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+                enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+            },
+            UserMetadata: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    serviceOffers: {
                         type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                            serviceOffers: {
-                                type: 'object',
-                                nullable: true,
-                                'x-dictionaryKey': {
-                                    $ref: '#/components/schemas/ServiceOfferKind',
-                                },
-                                additionalProperties: {
-                                    $ref: '#/components/schemas/BillingProviderKind',
-                                },
-                            },
-                            copy: {
-                                type: 'object',
-                                nullable: true,
-                                'x-dictionaryKey': {
-                                    $ref: '#/components/schemas/ServiceOfferKind',
-                                },
-                                additionalProperties: {
-                                    $ref: '#/components/schemas/BillingProviderKind',
-                                },
-                            },
+                        nullable: true,
+                        'x-dictionaryKey': {
+                            $ref: '#/components/schemas/ServiceOfferKind',
+                        },
+                        additionalProperties: {
+                            $ref: '#/components/schemas/BillingProviderKind',
                         },
                     },
+                    copy: {
+                        type: 'object',
+                        nullable: true,
+                        'x-dictionaryKey': {
+                            $ref: '#/components/schemas/ServiceOfferKind',
+                        },
+                        additionalProperties: {
+                            $ref: '#/components/schemas/BillingProviderKind',
+                        },
+                    },
+                },
+            },
         });
 
         const resultString = parseSchemas({ json });
@@ -740,44 +740,44 @@ export interface UserMetadata {
 
 it('should return type for a multiple "dictionary" types', async () => {
     const json = swaggerV3Mock({
-                BillingProviderKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': ['Legacy', 'Fusebill'],
-                    enum: ['Legacy', 'Fusebill'],
-                },
-                ServiceOfferKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
-                },
-                UserSubscriptions: {
+        BillingProviderKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Legacy', 'Fusebill'],
+            enum: ['Legacy', 'Fusebill'],
+        },
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution'],
+        },
+        UserSubscriptions: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                current: {
                     type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        current: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                $ref: '#/components/schemas/CurrentSubscription',
-                            },
-                        },
-                        next: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                $ref: '#/components/schemas/NextSubscription',
-                            },
-                        },
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
+                    },
+                    additionalProperties: {
+                        $ref: '#/components/schemas/CurrentSubscription',
                     },
                 },
+                next: {
+                    type: 'object',
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
+                    },
+                    additionalProperties: {
+                        $ref: '#/components/schemas/NextSubscription',
+                    },
+                },
+            },
+        },
     });
 
     const resultString = parseSchemas({ json });
@@ -799,82 +799,82 @@ export interface UserSubscriptions {
 
 it('should return type for a "dictionary" type boolean', async () => {
     const json = swaggerV3Mock({
-                ContentDtoOfCollectionDto: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        data: {
-                            type: 'array',
-                            nullable: true,
-                            items: {
-                                $ref: '#/components/schemas/CollectionDto',
-                            },
-                        },
-                        paging: {
-                            nullable: true,
-                            oneOf: [
-                                {
-                                    $ref: '#/components/schemas/PagingOptionsDto',
-                                },
-                            ],
-                        },
+        ContentDtoOfCollectionDto: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                data: {
+                    type: 'array',
+                    nullable: true,
+                    items: {
+                        $ref: '#/components/schemas/CollectionDto',
                     },
                 },
-                CollectionDto: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        id: {
-                            type: 'string',
-                            format: 'guid',
+                paging: {
+                    nullable: true,
+                    oneOf: [
+                        {
+                            $ref: '#/components/schemas/PagingOptionsDto',
                         },
-                        ownerId: {
-                            type: 'string',
-                            format: 'guid',
-                        },
-                        name: {
-                            type: 'string',
-                            nullable: true,
-                        },
-                        type: {
-                            $ref: '#/components/schemas/CollectionType',
-                        },
-                        creationTime: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                        lastModifiedTime: {
-                            type: 'string',
-                            format: 'date-time',
-                        },
-                        isSoftDeleted: {
-                            type: 'boolean',
-                        },
-                        collaborators: {
-                            type: 'array',
-                            nullable: true,
-                            items: {
-                                $ref: '#/components/schemas/CollaboratorDto',
-                            },
-                        },
-                        permissions: {
-                            type: 'object',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/UserOperation',
-                            },
-                            additionalProperties: {
-                                type: 'boolean',
-                            },
-                        },
-                    },
+                    ],
                 },
-                UserOperation: {
+            },
+        },
+        CollectionDto: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                id: {
                     type: 'string',
-                    description: '',
-                    'x-enumNames': ['Read', 'Write'],
-                    enum: ['Read', 'Write'],
+                    format: 'guid',
                 },
+                ownerId: {
+                    type: 'string',
+                    format: 'guid',
+                },
+                name: {
+                    type: 'string',
+                    nullable: true,
+                },
+                type: {
+                    $ref: '#/components/schemas/CollectionType',
+                },
+                creationTime: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+                lastModifiedTime: {
+                    type: 'string',
+                    format: 'date-time',
+                },
+                isSoftDeleted: {
+                    type: 'boolean',
+                },
+                collaborators: {
+                    type: 'array',
+                    nullable: true,
+                    items: {
+                        $ref: '#/components/schemas/CollaboratorDto',
+                    },
+                },
+                permissions: {
+                    type: 'object',
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/UserOperation',
+                    },
+                    additionalProperties: {
+                        type: 'boolean',
+                    },
+                },
+            },
+        },
+        UserOperation: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['Read', 'Write'],
+            enum: ['Read', 'Write'],
+        },
     });
 
     const resultString = parseSchemas({ json });
@@ -905,19 +905,12 @@ export type UserOperation = 'Read' | 'Write';
 it('should return overrided enum schema', async () => {
     // What will be fetched from Swagger Json
     const json = swaggerV3Mock({
-                ServiceOfferKind: {
-                    type: 'string',
-                    description: '',
-                    'x-enumNames': [
-                        'MasteringAndDistribution',
-                        'Video',
-                        'Samples',
-                        'Mastering',
-                        'Distribution',
-                        'Sessions',
-                    ],
-                    enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
-                },
+        ServiceOfferKind: {
+            type: 'string',
+            description: '',
+            'x-enumNames': ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+            enum: ['MasteringAndDistribution', 'Video', 'Samples', 'Mastering', 'Distribution', 'Sessions'],
+        },
     });
 
     const resultString = parseSchemas({
@@ -945,60 +938,60 @@ export type ServiceOfferKind = 'masteringAndDistribution' | 'video' | 'samples' 
 
 it('should return description', async () => {
     const json = swaggerV3Mock({
-                PlanFrequencyIdentifier: {
+        PlanFrequencyIdentifier: {
+            type: 'object',
+            description: 'PlanFrequencyIdentifier description',
+            additionalProperties: false,
+            properties: {
+                code: {
+                    type: 'string',
+                    description: 'The Fusebill plan code.',
+                    nullable: true,
+                },
+                currentQuantity: {
+                    type: 'number',
+                    description: 'The current quantity of the product within the subscription.',
+                    format: 'decimal',
+                },
+                numberOfCredits: {
+                    type: 'integer',
+                    description: 'The number of credits associated to this subscription product.',
+                    format: 'int32',
+                    nullable: true,
+                },
+                frequency: {
+                    description: 'The interval of the plan (monthly/yearly).',
+                    oneOf: [
+                        {
+                            $ref: '#/components/schemas/Interval',
+                        },
+                    ],
+                },
+                hasOverduePayment: {
                     type: 'object',
-                    description: 'PlanFrequencyIdentifier description',
-                    additionalProperties: false,
-                    properties: {
-                        code: {
-                            type: 'string',
-                            description: 'The Fusebill plan code.',
-                            nullable: true,
-                        },
-                        currentQuantity: {
-                            type: 'number',
-                            description: 'The current quantity of the product within the subscription.',
-                            format: 'decimal',
-                        },
-                        numberOfCredits: {
-                            type: 'integer',
-                            description: 'The number of credits associated to this subscription product.',
-                            format: 'int32',
-                            nullable: true,
-                        },
-                        frequency: {
-                            description: 'The interval of the plan (monthly/yearly).',
-                            oneOf: [
-                                {
-                                    $ref: '#/components/schemas/Interval',
-                                },
-                            ],
-                        },
-                        hasOverduePayment: {
-                            type: 'object',
-                            description: 'Says if the user has overdue payments by service offer.',
-                            nullable: true,
-                            'x-dictionaryKey': {
-                                $ref: '#/components/schemas/ServiceOfferKind',
-                            },
-                            additionalProperties: {
-                                type: 'boolean',
-                            },
-                        },
-                        userIds: {
-                            type: 'array',
-                            description: 'The user IDs.',
-                            items: {
-                                type: 'string',
-                                format: 'guid',
-                            },
-                        },
-                        isDefault: {
-                            type: 'boolean',
-                            description: 'Boolean description',
-                        },
+                    description: 'Says if the user has overdue payments by service offer.',
+                    nullable: true,
+                    'x-dictionaryKey': {
+                        $ref: '#/components/schemas/ServiceOfferKind',
+                    },
+                    additionalProperties: {
+                        type: 'boolean',
                     },
                 },
+                userIds: {
+                    type: 'array',
+                    description: 'The user IDs.',
+                    items: {
+                        type: 'string',
+                        format: 'guid',
+                    },
+                },
+                isDefault: {
+                    type: 'boolean',
+                    description: 'Boolean description',
+                },
+            },
+        },
     });
 
     const resultString = parseSchemas({ json });
@@ -1045,21 +1038,21 @@ export interface PlanFrequencyIdentifier {
 
 it('should return CollectionResponseDto', async () => {
     const json = swaggerV2Mock({
-            'CollectionResponseDto[StoredCreditCardDto]': {
-                title: 'CollectionResponse`1',
-                type: 'object',
-                properties: {
-                    data: {
-                        type: 'array',
-                        items: {
-                            $ref: '#/definitions/StoredCreditCardDto',
-                        },
-                    },
-                    paging: {
-                        $ref: '#/definitions/PagingDto',
+        'CollectionResponseDto[StoredCreditCardDto]': {
+            title: 'CollectionResponse`1',
+            type: 'object',
+            properties: {
+                data: {
+                    type: 'array',
+                    items: {
+                        $ref: '#/definitions/StoredCreditCardDto',
                     },
                 },
+                paging: {
+                    $ref: '#/definitions/PagingDto',
+                },
             },
+        },
     });
 
     const resultString = parseSchemas({ json });


### PR DESCRIPTION
## 📄  Description
Prettified tests (.spec files). All test objects where moved to right:
![2020-12-02_21-24-27](https://user-images.githubusercontent.com/22501553/100921183-de32ef80-34e4-11eb-908f-fc160d6d89d2.jpg)

**Why here?** Because it is almost impossible to detect simple changes in Part 3 with it.

## ✅  Checklist
- [x] Contains no duplicate/temporary code
- [x] Contains no sensitive information
- [ ] Error handling added
- [ ] Unit tests added

## Related PRs:
- Part 1: https://github.com/LandrAudio/openapi-codegen-typescript/pull/22
- Part 2: https://github.com/LandrAudio/openapi-codegen-typescript/pull/23
- Part 3: https://github.com/LandrAudio/openapi-codegen-typescript/pull/24

## 🔗  JIRA Issue
https://mixgenius.atlassian.net/browse/CHFE-790
