### PR TITLE
fix(types): fix mock values for simple dictionary types (integer, number, string)

### DIFF
--- a/src/typesConverter.ts
+++ b/src/typesConverter.ts
@@ -268,12 +268,37 @@ const convertToTypesFromSchemaProperties = ({
 
                         // Enum keys and Boolean values
                     } else if (xDictionaryKey[SwaggerProps.$ref]) {
-                        if (additionalProperties.type && additionalProperties.type === DataTypes.Boolean) {
+                        if (additionalProperties.type) {
                             const dictionaryRef = parseRefType(xDictionaryKey[SwaggerProps.$ref].split('/'));
 
-                            result += `${getDescription(
+                            let res;
+
+                            switch (additionalProperties.type) {
+                                case DataTypes.Boolean:
+                                    res = DataTypes.Boolean;
+                                    break;
+                                case DataTypes.Integer:
+                                    res = DataTypes.Number;
+                                    break;
+                                case DataTypes.Number:
+                                    res = DataTypes.Number;
+                                    break;
+                                case DataTypes.String:
+                                    res = DataTypes.String;
+                                    break;
+                                default:
+                                    res = ` "// TODO: Something in wrong" `;
+                                    break;
+                            }
+
+                            result += getDictionaryValueResultString({
                                 description,
-                            )}    ${propertyName}: {\n[key in ${dictionaryRef}]: boolean; \n }; \n`;
+                                dictionaryRef,
+                                propertyName,
+                                value: res,
+                            });
+                        } else {
+                            result += ` "// TODO: Something in wrong" `;
                         }
                     } else {
                         result += ' "// TODO: Something in wrong" ';
@@ -303,6 +328,20 @@ export const parseObject = ({ schema, schemaKey }: { schema: any; schemaKey: str
     } else {
         return convertToTypesFromSchemaProperties({ schemaKey, schema });
     }
+};
+
+export const getDictionaryValueResultString = ({
+    description,
+    propertyName,
+    dictionaryRef,
+    value,
+}: {
+    description: string;
+    propertyName: string;
+    dictionaryRef: string;
+    value: string;
+}): string => {
+    return `${getDescription(description)}    ${propertyName}: {\n[key in ${dictionaryRef}]: ${value}; \n }; \n`;
 };
 
 /**

--- a/tests/mockConverter.test.ts
+++ b/tests/mockConverter.test.ts
@@ -1537,3 +1537,206 @@ export const aStoredCreditCardDtoAPI = (overrides?: Partial<StoredCreditCardDto>
 `;
     expect(result).toEqual(expectedString);
 });
+
+describe('Dictionary type', () => {
+    it('should generate mock for integer values', async () => {
+        const json = aSwaggerV3Mock({
+            GlobalStateCounters: {
+                type: 'object',
+                properties: {
+                    states: {
+                        type: 'object',
+                        nullable: true,
+                        'x-dictionaryKey': {
+                            $ref: '#/components/schemas/ProductState',
+                        },
+                        additionalProperties: {
+                            type: 'integer',
+                            format: 'int32',
+                        },
+                    },
+                },
+            },
+            ProductState: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Draft', 'ConfirmDraft'],
+                enum: ['Draft', 'ConfirmDraft'],
+            },
+        });
+
+        const result = await convertToMocks({
+            json,
+            fileName: "doesn't matter",
+            folderPath: './someFolder',
+            typesPath: './pathToTypes',
+        });
+
+        const expectedString = `/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {GlobalStateCounters, ProductState} from './pathToTypes';
+
+export const aGlobalStateCountersAPI = (overrides?: Partial<GlobalStateCounters>): GlobalStateCounters => {
+  return {
+    states: { 
+"Draft": 14,
+"ConfirmDraft": 56,
+},
+  ...overrides,
+  };
+};
+ 
+`;
+        expect(result).toEqual(expectedString);
+    });
+
+    it('should generate mock for number values', async () => {
+        const json = aSwaggerV3Mock({
+            GlobalStateCounters: {
+                type: 'object',
+                properties: {
+                    states: {
+                        type: 'object',
+                        nullable: true,
+                        'x-dictionaryKey': {
+                            $ref: '#/components/schemas/ProductState',
+                        },
+                        additionalProperties: {
+                            type: 'number',
+                        },
+                    },
+                },
+            },
+            ProductState: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Draft', 'ConfirmDraft'],
+                enum: ['Draft', 'ConfirmDraft'],
+            },
+        });
+
+        const result = await convertToMocks({
+            json,
+            fileName: "doesn't matter",
+            folderPath: './someFolder',
+            typesPath: './pathToTypes',
+        });
+
+        const expectedString = `/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {GlobalStateCounters, ProductState} from './pathToTypes';
+
+export const aGlobalStateCountersAPI = (overrides?: Partial<GlobalStateCounters>): GlobalStateCounters => {
+  return {
+    states: { 
+"Draft": 13.546639564447105,
+"ConfirmDraft": 55.710112932138145,
+},
+  ...overrides,
+  };
+};
+ 
+`;
+        expect(result).toEqual(expectedString);
+    });
+
+    it('should generate mock for string values', async () => {
+        const json = aSwaggerV3Mock({
+            GlobalStateCounters: {
+                type: 'object',
+                properties: {
+                    states: {
+                        type: 'object',
+                        nullable: true,
+                        'x-dictionaryKey': {
+                            $ref: '#/components/schemas/ProductState',
+                        },
+                        additionalProperties: {
+                            type: 'string',
+                        },
+                    },
+                },
+            },
+            ProductState: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Draft', 'ConfirmDraft'],
+                enum: ['Draft', 'ConfirmDraft'],
+            },
+        });
+
+        const result = await convertToMocks({
+            json,
+            fileName: "doesn't matter",
+            folderPath: './someFolder',
+            typesPath: './pathToTypes',
+        });
+
+        const expectedString = `/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {GlobalStateCounters, ProductState} from './pathToTypes';
+
+export const aGlobalStateCountersAPI = (overrides?: Partial<GlobalStateCounters>): GlobalStateCounters => {
+  return {
+    states: { 
+"Draft": eos iste consequatur delectus sit veniam in,
+"ConfirmDraft": laborum voluptas molestiae ad architecto praesentium rerum,
+},
+  ...overrides,
+  };
+};
+ 
+`;
+        expect(result).toEqual(expectedString);
+    });
+
+    it('should generate TODO error value if "additionalProperties" is wrong', async () => {
+        const json = aSwaggerV3Mock({
+            GlobalStateCounters: {
+                type: 'object',
+                properties: {
+                    states: {
+                        type: 'object',
+                        nullable: true,
+                        'x-dictionaryKey': {
+                            $ref: '#/components/schemas/ProductState',
+                        },
+                        additionalProperties: {
+                            somethingIsWrong: 'error',
+                        },
+                    },
+                },
+            },
+            ProductState: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Draft', 'ConfirmDraft'],
+                enum: ['Draft', 'ConfirmDraft'],
+            },
+        });
+
+        const result = await convertToMocks({
+            json,
+            fileName: "doesn't matter",
+            folderPath: './someFolder',
+            typesPath: './pathToTypes',
+        });
+
+        const expectedString = `/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {GlobalStateCounters, ProductState} from './pathToTypes';
+
+export const aGlobalStateCountersAPI = (overrides?: Partial<GlobalStateCounters>): GlobalStateCounters => {
+  return {
+    states: { 
+"Draft": " // TODO: Wrong dictionary value",
+"ConfirmDraft": " // TODO: Wrong dictionary value",
+},
+  ...overrides,
+  };
+};
+ 
+`;
+        expect(result).toEqual(expectedString);
+    });
+});

--- a/tests/typeConverter.test.ts
+++ b/tests/typeConverter.test.ts
@@ -1065,3 +1065,123 @@ it('should return CollectionResponseDto', async () => {
 `;
     expect(resultString).toEqual(expectedString);
 });
+
+describe('Dictionary types', () => {
+    it('should return dictionary value type for integer', async () => {
+        const json = aSwaggerV3Mock({
+            GlobalStateCounters: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    states: {
+                        type: 'object',
+                        nullable: true,
+                        'x-dictionaryKey': {
+                            $ref: '#/components/schemas/ProductState',
+                        },
+                        additionalProperties: {
+                            type: 'integer',
+                            format: 'int32',
+                        },
+                    },
+                },
+            },
+            ProductState: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Draft', 'ConfirmDraft'],
+                enum: ['Draft', 'ConfirmDraft'],
+            },
+        });
+
+        const resultString = parseSchemas({ json });
+
+        const expectedString = `export interface GlobalStateCounters {
+    states: {
+[key in ProductState]: number; 
+ }; 
+}
+export type ProductState = 'Draft' | 'ConfirmDraft';
+ 
+`;
+        expect(resultString).toEqual(expectedString);
+    });
+
+    it('should return dictionary value type for number', async () => {
+        const json = aSwaggerV3Mock({
+            GlobalStateCounters: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    states: {
+                        type: 'object',
+                        nullable: true,
+                        'x-dictionaryKey': {
+                            $ref: '#/components/schemas/ProductState',
+                        },
+                        additionalProperties: {
+                            type: 'number',
+                        },
+                    },
+                },
+            },
+            ProductState: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Draft', 'ConfirmDraft'],
+                enum: ['Draft', 'ConfirmDraft'],
+            },
+        });
+
+        const resultString = parseSchemas({ json });
+
+        const expectedString = `export interface GlobalStateCounters {
+    states: {
+[key in ProductState]: number; 
+ }; 
+}
+export type ProductState = 'Draft' | 'ConfirmDraft';
+ 
+`;
+        expect(resultString).toEqual(expectedString);
+    });
+
+    it('should return dictionary value type for string', async () => {
+        const json = aSwaggerV3Mock({
+            GlobalStateCounters: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    states: {
+                        type: 'object',
+                        nullable: true,
+                        'x-dictionaryKey': {
+                            $ref: '#/components/schemas/ProductState',
+                        },
+                        additionalProperties: {
+                            type: 'string',
+                        },
+                    },
+                },
+            },
+            ProductState: {
+                type: 'string',
+                description: '',
+                'x-enumNames': ['Draft', 'ConfirmDraft'],
+                enum: ['Draft', 'ConfirmDraft'],
+            },
+        });
+
+        const resultString = parseSchemas({ json });
+
+        const expectedString = `export interface GlobalStateCounters {
+    states: {
+[key in ProductState]: string; 
+ }; 
+}
+export type ProductState = 'Draft' | 'ConfirmDraft';
+ 
+`;
+        expect(resultString).toEqual(expectedString);
+    });
+});


### PR DESCRIPTION
Fixed mock-gen for dictionary simple types - integer, number and string

## Related: 
Part-2: https://github.com/LandrAudio/openapi-codegen-typescript/pull/28

## Jira:
https://mixgenius.atlassian.net/browse/PROJ-5456