### PR TITLE
feat: support dictionary of array of complex type

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.160.0/containers/typescript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version: 14, 12, 10
+ARG VARIANT="14-buster"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node packages
+# RUN su node -c "npm install -g <your-package-list -here>"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.160.0/containers/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick a Node version: 10, 12, 14
+		"args": { 
+			"VARIANT": "14"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "yarn install",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node"
+}

--- a/src/MockGenerateHelper.ts
+++ b/src/MockGenerateHelper.ts
@@ -233,6 +233,9 @@ export class MockGenerateHelper {
                     case DataTypes.Boolean:
                         result = 'true';
                         break;
+                    case DataTypes.Array:
+                        result = '[]';
+                        break;
                     default: {
                         result = ' // TODO: Wrong dictionary value';
                         break;

--- a/src/typesConverter.ts
+++ b/src/typesConverter.ts
@@ -286,8 +286,14 @@ const convertToTypesFromSchemaProperties = ({
                                 case DataTypes.String:
                                     res = DataTypes.String;
                                     break;
+                                case DataTypes.Array:
+                                    if (additionalProperties.items && additionalProperties.items[SwaggerProps.$ref]) {
+                                       res = `${parseRefType(additionalProperties.items[SwaggerProps.$ref].split('/'))}[]`;
+                                    } else {
+                                       res = ` "// TODO: Something is wrong" `;
+                                    }
                                 default:
-                                    res = ` "// TODO: Something in wrong" `;
+                                    res = ` "// TODO: Something is wrong" `;
                                     break;
                             }
 
@@ -298,10 +304,10 @@ const convertToTypesFromSchemaProperties = ({
                                 value: res,
                             });
                         } else {
-                            result += ` "// TODO: Something in wrong" `;
+                            result += ` "// TODO: Something is wrong" `;
                         }
                     } else {
-                        result += ' "// TODO: Something in wrong" ';
+                        result += ' "// TODO: Something is wrong" ';
                     }
                 }
             },

--- a/src/typesConverter.ts
+++ b/src/typesConverter.ts
@@ -292,8 +292,9 @@ const convertToTypesFromSchemaProperties = ({
                                     } else {
                                        res = ` "// TODO: Something is wrong" `;
                                     }
+                                    break;
                                 default:
-                                    res = ` "// TODO: Something is wrong" `;
+                                    res = ` "// TODO: Something is wrong, type ${additionalProperties.type} is not supported" `;
                                     break;
                             }
 

--- a/tests/__snapshots__/mockConverter.test.ts.snap
+++ b/tests/__snapshots__/mockConverter.test.ts.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Dictionary type should generate mocks for a "dictionary" type array 1`] = `
+"/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {ComplexDto, MainDto, Role} from './pathToTypes';
+
+export const aComplexDtoAPI = (overrides?: Partial<ComplexDto>): ComplexDto => {
+  return {
+    name: 'name-complexdto',
+  ...overrides,
+  };
+};
+
+export const aMainDtoAPI = (overrides?: Partial<MainDto>): MainDto => {
+  return {
+    contributors: { 
+\\"role1\\": [],
+\\"role2\\": [],
+\\"role3\\": [],
+},
+  ...overrides,
+  };
+};
+ 
+"
+`;

--- a/tests/__snapshots__/typeConverter.test.ts.snap
+++ b/tests/__snapshots__/typeConverter.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should return type for a "dictionary" type array 1`] = `
+"export interface ComplexDto {
+    name?: string;
+}
+export interface MainDto {
+    contributors: {
+[key in Role]: ComplexDto[]; 
+ }; 
+}
+export type Role = 'role1' | 'role2' | 'role3';
+ 
+"
+`;

--- a/tests/mockConverter.test.ts
+++ b/tests/mockConverter.test.ts
@@ -1739,4 +1739,83 @@ export const aGlobalStateCountersAPI = (overrides?: Partial<GlobalStateCounters>
 `;
         expect(result).toEqual(expectedString);
     });
+
+    it('should generate mocks for a "dictionary" type array', async () => {
+        const json = aSwaggerV3Mock({
+            ComplexDto: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                name: {
+                  type: 'string',
+                  nullable: true
+                }
+              }
+            },
+            MainDto: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                contributors: {
+                  type: 'object',
+                  nullable: true,
+                  'x-dictionaryKey': {
+                    $ref: '#/components/schemas/Role'
+                  },
+                  additionalProperties: {
+                    type: 'array',
+                    items: {
+                      $ref: '#/components/schemas/ComplexDto'
+                    }
+                  }
+                }
+              }
+            },
+            Role: {
+              type: 'string',
+              'x-enumNames': [
+                'Role1',
+                'Role2',
+                'Role3'
+              ],
+              enum: [
+                'role1',
+                'role2',
+                'role3'
+              ]
+            },
+        });
+    
+        const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {ComplexDto, MainDto, Role} from './pathToTypes';
+
+export const aComplexDtoAPI = (overrides?: Partial<ComplexDto>): ComplexDto => {
+  return {
+    name: 'name-complexdto',
+  ...overrides,
+  };
+};
+
+export const aMainDtoAPI = (overrides?: Partial<MainDto>): MainDto => {
+  return {
+    contributors: { 
+"role1": [],
+"role2": [],
+"role3": [],
+},
+  ...overrides,
+  };
+};
+ 
+`;
+        const result = await convertToMocks({
+            json,
+            fileName: "doesn't matter",
+            folderPath: './someFolder',
+            typesPath: './pathToTypes',
+        });
+    
+        expect(result).toEqual(expected);
+    });    
 });

--- a/tests/mockConverter.test.ts
+++ b/tests/mockConverter.test.ts
@@ -1786,29 +1786,6 @@ export const aGlobalStateCountersAPI = (overrides?: Partial<GlobalStateCounters>
             },
         });
     
-        const expected = `/* eslint-disable @typescript-eslint/no-use-before-define */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import {ComplexDto, MainDto, Role} from './pathToTypes';
-
-export const aComplexDtoAPI = (overrides?: Partial<ComplexDto>): ComplexDto => {
-  return {
-    name: 'name-complexdto',
-  ...overrides,
-  };
-};
-
-export const aMainDtoAPI = (overrides?: Partial<MainDto>): MainDto => {
-  return {
-    contributors: { 
-"role1": [],
-"role2": [],
-"role3": [],
-},
-  ...overrides,
-  };
-};
- 
-`;
         const result = await convertToMocks({
             json,
             fileName: "doesn't matter",
@@ -1816,6 +1793,6 @@ export const aMainDtoAPI = (overrides?: Partial<MainDto>): MainDto => {
             typesPath: './pathToTypes',
         });
     
-        expect(result).toEqual(expected);
+        expect(result).toMatchSnapshot();
     });    
 });

--- a/tests/typeConverter.test.ts
+++ b/tests/typeConverter.test.ts
@@ -1234,18 +1234,6 @@ it('should return type for a "dictionary" type array', async () => {
 
     const resultString = parseSchemas({ json });
 
-    const expectedString = `export interface ComplexDto {
-    name?: string;
-}
-export interface MainDto {
-    contributors: {
-[key in Role]: ComplexDto[]; 
- }; 
-}
-export type Role = 'role1' | 'role2' | 'role3';
- 
-`;
-
-    expect(resultString).toEqual(expectedString);
+    expect(resultString).toMatchSnapshot();
 });
 

--- a/tests/typeConverter.test.ts
+++ b/tests/typeConverter.test.ts
@@ -1185,3 +1185,67 @@ export type ProductState = 'Draft' | 'ConfirmDraft';
         expect(resultString).toEqual(expectedString);
     });
 });
+
+it('should return type for a "dictionary" type array', async () => {
+    const json = aSwaggerV3Mock({
+        ComplexDto: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            name: {
+              type: 'string',
+              nullable: true
+            }
+          }
+        },
+        MainDto: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            contributors: {
+              type: 'object',
+              nullable: true,
+              'x-dictionaryKey': {
+                $ref: '#/components/schemas/Role'
+              },
+              additionalProperties: {
+                type: 'array',
+                items: {
+                  $ref: '#/components/schemas/ComplexDto'
+                }
+              }
+            }
+          }
+        },
+        Role: {
+          type: 'string',
+          'x-enumNames': [
+            'Role1',
+            'Role2',
+            'Role3'
+          ],
+          enum: [
+            'role1',
+            'role2',
+            'role3'
+          ]
+        },
+    });
+
+    const resultString = parseSchemas({ json });
+
+    const expectedString = `export interface ComplexDto {
+    name?: string;
+}
+export interface MainDto {
+    contributors: {
+[key in Role]: ComplexDto[]; 
+ }; 
+}
+export type Role = 'role1' | 'role2' | 'role3';
+ 
+`;
+
+    expect(resultString).toEqual(expectedString);
+});
+


### PR DESCRIPTION
## Description

Add support of dictionary of array of complex type.

A swagger excerpt would be like this:
```json
          "MainDto": {
            "type": "object",
            "description": "",
            "nullable": true,
            "x-dictionaryKey": {
              "$ref": "#/components/schemas/Role"
            },
            "additionalProperties": {
              "type": "array",
              "items": {
                "$ref": "#/components/schemas/ComplexDto"
              }
            }
          }
```

Unit tests have been added, using [jest snapshot feature](https://jestjs.io/docs/en/snapshot-testing).

It also includes .devcontainer files to develop inside a Docker container on a host with no Node/TypeScript environment.

## Checklist

[x] Unit tests
[x] Generated mocks