### PR TITLE
feat: support any[]

### DIFF
--- a/src/typesConverter.ts
+++ b/src/typesConverter.ts
@@ -214,7 +214,7 @@ const convertToTypesFromSchemaProperties = ({
                             if (swaggerType === 'integer') {
                                 type = 'number';
                             } else {
-                                type = swaggerType;
+                                type = swaggerType || 'any';
                             }
                         }
 

--- a/tests/typeConverter.test.ts
+++ b/tests/typeConverter.test.ts
@@ -678,6 +678,31 @@ export interface AssetFileDto {
         expect(resultString).toEqual(expectedString);
     });
 
+    it('should return "any" type items in array for items without a type', async () => {
+        const json = aSwaggerV3Mock({
+            ArrayOfAny: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                    invoiceNumbers: {
+                        type: 'array',
+                        nullable: true,
+                        items: {},
+                    },
+                },
+            },
+        });
+
+        const resultString = parseSchemas({ json });
+
+        const expectedString = `export interface ArrayOfAny {
+    invoiceNumbers?: any[];
+}
+ 
+`;
+        expect(resultString).toEqual(expectedString);
+    });
+
     it('should return type for a "dictionary"', async () => {
         const json = aSwaggerV3Mock({
             BillingProviderKind: {


### PR DESCRIPTION
### Description

Support any[] arrays. Without this, JArray from our BE are parsed as `undefined[]`.

#### Before
![image](https://user-images.githubusercontent.com/39346142/230164133-2ecca88f-8b98-4a30-941e-87c55abababa.png)

#### After
![image](https://user-images.githubusercontent.com/39346142/230169531-e7f08039-4feb-4d30-b854-6499c92fdd45.png)

