### PR TITLE
fix(mocks): fix duration format in mocks

### DIFF
--- a/src/MockGenerateHelper.ts
+++ b/src/MockGenerateHelper.ts
@@ -43,10 +43,12 @@ export class MockGenerateHelper {
             value = `'${this.casual.email}'`;
         } else if (format === StringFormats.Uri) {
             value = `'${this.casual.url}'`;
+        } else if (format === StringFormats.Duration) {
+            value = `'${this.casual.integer(0, 1000)}'`;
         }
 
         if (!value) {
-            value = 'TODO: FIX';
+            value = `'TODO: FIX'`;
         }
 
         return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export enum DataTypes {
 export enum StringFormats {
     Date = 'date',
     DateTime = 'date-time',
+    Duration = 'duration',
     Password = 'password',
     Byte = 'byte',
     Binary = 'binary',

--- a/tests/mockConverter.test.ts
+++ b/tests/mockConverter.test.ts
@@ -171,6 +171,31 @@ export const aDatesAPI = (overrides?: Partial<Dates>): Dates => {
     expect(result).toEqual(expectedString);
 });
 
+it('should generate duration format', async () => {
+    const schema = {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+            duration: {
+                type: 'string',
+                format: 'duration',
+            },
+        },
+    };
+
+    const result = parseSchema({ schema, name: 'Dates' });
+
+    const expectedString = `
+export const aDatesAPI = (overrides?: Partial<Dates>): Dates => {
+  return {
+    duration: '902',
+  ...overrides,
+  };
+};
+`;
+    expect(result).toEqual(expectedString);
+});
+
 it('should generate boolean type', async () => {
     const schema = {
         type: 'object',
@@ -1785,14 +1810,14 @@ export const aGlobalStateCountersAPI = (overrides?: Partial<GlobalStateCounters>
               ]
             },
         });
-    
+
         const result = await convertToMocks({
             json,
             fileName: "doesn't matter",
             folderPath: './someFolder',
             typesPath: './pathToTypes',
         });
-    
+
         expect(result).toMatchSnapshot();
-    });    
+    });
 });


### PR DESCRIPTION
*Description*

Fix "duration" format returned by swagger.

Also fixed unknown formats to display the string `TODO:FIX` instead of breaking the syntax

**Before**
![CleanShot 2023-08-21 at 11 39 50](https://github.com/LandrAudio/openapi-codegen-typescript/assets/755469/3e70bb23-c796-42f0-91ef-73d92fd81d71)

**After**
Unkown

![CleanShot 2023-08-21 at 11 47 29](https://github.com/LandrAudio/openapi-codegen-typescript/assets/755469/9084a8ed-b9ba-4437-aab7-274b60e98ba2)

Duration
![CleanShot 2023-08-21 at 11 50 40](https://github.com/LandrAudio/openapi-codegen-typescript/assets/755469/6ad14ed6-7ae8-40f8-8bf4-3ee3605a1a35)


